### PR TITLE
NextJS: Load iFrame in ChatPage

### DIFF
--- a/web/nextjs/src/actions/signOut.ts
+++ b/web/nextjs/src/actions/signOut.ts
@@ -2,11 +2,14 @@
 
 import { getSession } from "@/lib/session";
 import { redirect } from "next/navigation";
+import { revalidateTag } from "next/cache";
+import { getChatSignedAppUrlCacheKey } from "@/lib/server";
 
 export async function signOut() {
   const session = await getSession();
   // Destroy the session
   session.destroy();
-
+  // Invalidate the chat signed app url cache
+  revalidateTag(getChatSignedAppUrlCacheKey(session.userId));
   redirect("/login");
 }

--- a/web/nextjs/src/app/dashboard/chat/page.tsx
+++ b/web/nextjs/src/app/dashboard/chat/page.tsx
@@ -1,10 +1,15 @@
+import ChatPage from "@/components/ChatPage";
+import { getUser } from "@/lib/mocks";
+import { getCounselSignedAppUrl } from "@/lib/server";
+import { getSession } from "@/lib/session";
+
 /**
- * Chat page doesn't render anything as the iframe is rendered in the layout.
- * However its here for NextJS to consider it a valid page.
- *
- * NOTE: if you just render the iFrame here, it will get torn down by the browser on navigation and flash each time a user navigates to this page.
- * This is a limitation of NextJS.
+ * Chat page renders the Counsel app inside an iframe.
  */
-export default function Chat() {
-  return <></>;
+export default async function Chat() {
+  const session = await getSession();
+  const user = getUser(session.userId);
+  const signedAppUrl = await getCounselSignedAppUrl(user.id);
+
+  return <ChatPage signedAppUrl={signedAppUrl} />;
 }

--- a/web/nextjs/src/app/dashboard/layout.tsx
+++ b/web/nextjs/src/app/dashboard/layout.tsx
@@ -1,24 +1,12 @@
 import type React from "react";
 import Header from "@/components/Header";
-import { getCounselSignedAppUrl } from "@/lib/server";
-import { getUser } from "@/lib/mocks";
-import ChatPage from "@/components/ChatPage";
-import { getSession } from "@/lib/session";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const session = await getSession();
-  const user = getUser(session.userId);
-  const signedAppUrl = await getCounselSignedAppUrl(user.id);
-
   return (
     <div className="flex flex-col h-screen w-screen overflow-hidden">
       <Header />
       {/* Main Content */}
-      <main className="flex-1 h-full min-h-0">
-        {/* Always render the ChatPage in the main content so that it doesn't get torn down by the browser on navigation */}
-        <ChatPage signedAppUrl={signedAppUrl} />
-        {children}
-      </main>
+      <main className="flex-1 h-full min-h-0">{children}</main>
     </div>
   );
 }

--- a/web/nextjs/src/components/AccountPage.tsx
+++ b/web/nextjs/src/components/AccountPage.tsx
@@ -5,10 +5,13 @@ import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { User } from "@/types/user";
 import { signOut } from "@/actions/signOut";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 export function AccountPage({ user }: { user: User }) {
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
   const handleSignOut = useCallback(() => {
+    setIsSigningOut(true);
     signOut();
   }, []);
 
@@ -53,7 +56,12 @@ export function AccountPage({ user }: { user: User }) {
 
               <div className="pt-4">
                 <Button>Edit Profile</Button>
-                <Button variant="outline" className="ml-2" onClick={handleSignOut}>
+                <Button
+                  variant="outline"
+                  className="ml-2"
+                  onClick={handleSignOut}
+                  loading={isSigningOut}
+                >
                   Sign Out
                 </Button>
               </div>

--- a/web/nextjs/src/components/ChatPage.tsx
+++ b/web/nextjs/src/components/ChatPage.tsx
@@ -1,28 +1,18 @@
 "use client";
 
-import { usePathname } from "next/navigation";
 import { CounselApp } from "./counsel/CounselApp";
 import { cn } from "@/lib/utils";
 
 /**
- * Explanation:
- * - The ChatPage is always mounted in the app so that the iFrame is persistent and doesn't get torn down by the browser on navigation.
- * - If the page is not the chat page, the iframe is hidden.
- *
- * Feel free to follow this pattern in order to create an experience that is seamless and performant for your users.
- * It is also okay to reload the iframe and only mount it on a single page but it will cause a flash each time a user navigates to that page.
+ * ChatPage is a component that renders a Counsel app inside an iframe.
  */
 export default function ChatPage({ signedAppUrl }: { signedAppUrl: string }) {
-  const pathname = usePathname();
-  const isChatPage = pathname.startsWith("/dashboard/chat");
-  const hideIframe = !isChatPage;
-
   return (
     <CounselApp
       signedAppUrl={signedAppUrl}
       // Importantly the parent div(s) must have an explicit height set for height: 100% to work
       // In this case the parent is h-screen so the iframe will take the full height
-      className={cn("h-full w-full", hideIframe && "hidden")}
+      className={cn("h-full w-full")}
     />
   );
 }

--- a/web/nextjs/src/components/counsel/CounselApp.tsx
+++ b/web/nextjs/src/components/counsel/CounselApp.tsx
@@ -12,7 +12,6 @@ export type CounselAppProps = {
  */
 export const CounselApp = dynamic<CounselAppProps>(
   () => {
-    console.log("importing CounselAppClient");
     return import("./CounselAppClient");
   },
 


### PR DESCRIPTION
- Caching the iFrame broke focus because you can't load a hidden iFrame it messes with the browser's focus logic
- Instead we just load it everytime someone clicks the chat with a doctor button
- We cache the signed app url fetch so we can reload quickly on navigation events
- This is closer to how we recommend setting up our iFrame