### PR TITLE
iOS Web View Improvements

### DIFF
--- a/mobile/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatView.swift
+++ b/mobile/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatView.swift
@@ -30,6 +30,8 @@ struct ChatView: View {
             }
         }
         .task {
+            guard chatUrl == nil else { return }
+
             do {
                 let url = try await API.User.fetchChatURL(token: token)
                 chatUrl = url
@@ -37,13 +39,17 @@ struct ChatView: View {
                 showErrorModal = true
             }
         }
-        .onDisappear {
-            chatUrl = nil
-        }
         .alert("Error", isPresented: $showErrorModal) {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Unable to load chat. Please try again later.")
+        }
+        .onChange(of: token) { _, newToken in
+            // When the user signs out (token cleared), reset chat state
+            if newToken == nil {
+                chatUrl = nil
+                showOnboarding = true
+            }
         }
     }
 }

--- a/mobile/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatView.swift
+++ b/mobile/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatView.swift
@@ -16,9 +16,7 @@ struct ChatView: View {
     
     var body: some View {
         NavigationStack {
-            if showOnboarding {
-                OnboardingPagesView(isPresented: $showOnboarding)
-            } else {
+            ZStack {
                 Group {
                     if let chatUrl = chatUrl {
                         WebView(url: chatUrl)
@@ -26,6 +24,9 @@ struct ChatView: View {
                     } else {
                         ProgressView()
                     }
+                }
+                if showOnboarding {
+                    OnboardingPagesView(isPresented: $showOnboarding)
                 }
             }
         }

--- a/mobile/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatView.swift
+++ b/mobile/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatView.swift
@@ -27,8 +27,11 @@ struct ChatView: View {
                 }
                 if showOnboarding {
                     OnboardingPagesView(isPresented: $showOnboarding)
+                        .zIndex(1)
+                        .transition(.opacity)
                 }
             }
+            .animation(.easeOut(duration: 0.5), value: showOnboarding)
         }
         .task {
             guard chatUrl == nil else { return }

--- a/mobile/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/OnboardingPagesView.swift
+++ b/mobile/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/OnboardingPagesView.swift
@@ -44,6 +44,7 @@ struct OnboardingPagesView: View {
             .tint(.brandLightBlue)
             .padding()
         }
+        .background(.white)
         .navigationBarHidden(true)
     }
 }


### PR DESCRIPTION
- persists chat view on tab changes
- resets onboarding and chat state on sign out
- preloads chat web view with onboarding fade out transition

![Simulator Screen Recording - iPhone 16 Pro - 2025-05-15 at 10 01 43](https://github.com/user-attachments/assets/2688eae1-b0b9-421e-8473-5a0d0c2bb083)
