### PR TITLE
chore: e2e automation tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
-## Run ./start.sh which will download secrets to .env.local
+## Local app dev (Next / Node): run ./start.sh to download Doppler secrets into .env.local
+## and copy them into web/nextjs/.env.local and server/nodejs/.env.local.
 
 # The port to run the server on
 PORT=4003
-# The Iron Session secret
-IRON_SESSION_SECRET=your_iron_session_secret_here 
-# ACCESS_CODE_CONFIGS
+# The Iron Session secret (use IRON_SESSION_PASSWORD; legacy names may vary by template)
+IRON_SESSION_PASSWORD=your_iron_session_password_at_least_32_chars
+# ACCESS_CODE_CONFIGS (JSON string)
 ACCESS_CODE_CONFIGS=your_JSON_access_code_config

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # CODEOWNERS
-# 1. All PRs are reviewed by @jaisal1024
-* @jaisal1024
+# All PRs reviewed by the app reviewers team
+* @counsel-health/@counsel-embedded-example-apps-reviewers

--- a/.github/workflows/cd-nextjs-web.yml
+++ b/.github/workflows/cd-nextjs-web.yml
@@ -35,18 +35,18 @@ jobs:
         working-directory: ./web/nextjs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Instructions: https://github.com/google-github-actions/auth?tab=readme-ov-file#direct-wif
       - name: Google Auth
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           credentials_json: "${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}"
           token_format: "access_token"
 
       - name: Login to Google Artifact Registry (GAR)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGION }}-docker.pkg.dev
           username: _json_key
@@ -59,7 +59,7 @@ jobs:
 
       - name: Deploy to Cloud Run
         id: deploy
-        uses: google-github-actions/deploy-cloudrun@v2
+        uses: google-github-actions/deploy-cloudrun@v3
         with:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}

--- a/.github/workflows/cd-nextjs-web.yml
+++ b/.github/workflows/cd-nextjs-web.yml
@@ -61,6 +61,7 @@ jobs:
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v3
         with:
+          wait: "true"
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
           image: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}

--- a/.github/workflows/cd-nodejs-server.yml
+++ b/.github/workflows/cd-nodejs-server.yml
@@ -35,18 +35,18 @@ jobs:
         working-directory: ./server/nodejs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Instructions: https://github.com/google-github-actions/auth?tab=readme-ov-file#direct-wif
       - name: Google Auth
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           credentials_json: "${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}"
           token_format: "access_token"
 
       - name: Login to Google Artifact Registry (GAR)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGION }}-docker.pkg.dev
           username: _json_key
@@ -59,7 +59,7 @@ jobs:
 
       - name: Deploy to Cloud Run
         id: deploy
-        uses: google-github-actions/deploy-cloudrun@v2
+        uses: google-github-actions/deploy-cloudrun@v3
         with:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}

--- a/.github/workflows/cd-nodejs-server.yml
+++ b/.github/workflows/cd-nodejs-server.yml
@@ -61,6 +61,7 @@ jobs:
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v3
         with:
+          wait: "true"
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
           image: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,0 +1,134 @@
+name: E2E
+on:
+  pull_request:
+    paths:
+      - "automation-testing/**"
+      - "web/nextjs/**"
+      - "server/nodejs/**"
+      - "docker-compose.yml"
+      - "start.sh"
+      - "doppler.yaml"
+      - ".github/workflows/ci-e2e.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Mount automation-testing node_modules (stickydisk)
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ runner.os }}-counsel-embedded-e2e-bun-${{ hashFiles('automation-testing/bun.lock') }}
+          path: automation-testing/node_modules
+
+      - name: Install automation-testing dependencies
+        working-directory: ./automation-testing
+        run: bun install --frozen-lockfile
+
+      - name: Fetch secrets from Doppler
+        uses: dopplerhq/secrets-fetch-action@v1.3.1
+        with:
+          doppler-token: ${{ secrets.DOPPLER_DEV_CI_TOKEN }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG }}
+          inject-env-vars: true
+
+      - name: Write .env.local for Docker Compose
+        run: |
+          set -euo pipefail
+          umask 077
+          python3 << 'PY'
+          import os
+          import shlex
+
+          keys = (
+              "IRON_SESSION_PASSWORD",
+              "JWT_SECRET",
+              "COUNSEL_WEBHOOK_SECRET",
+              "ACCESS_CODE_CONFIGS",
+          )
+          with open(".env.local", "w", encoding="utf-8") as f:
+              for k in keys:
+                  v = os.environ.get(k)
+                  if v is not None and v != "":
+                      f.write(f"{k}={shlex.quote(v)}\n")
+          PY
+
+      - name: Docker Compose up
+        run: docker compose up --build -d
+
+      - name: Wait for web and API
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 90); do
+            if curl -sf http://127.0.0.1:4003/health >/dev/null 2>&1 && curl -sf http://127.0.0.1:3001/login >/dev/null 2>&1; then
+              echo "Services are up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Timeout waiting for services"
+          docker compose ps
+          docker compose logs --tail 80
+          exit 1
+
+      - name: Mount Playwright browsers cache (stickydisk)
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ runner.os }}-counsel-embedded-e2e-playwright-${{ hashFiles('automation-testing/package.json', 'automation-testing/bun.lock') }}
+          path: ~/.cache/ms-playwright
+
+      - name: Install Playwright Chromium
+        working-directory: ./automation-testing
+        run: bunx playwright install chromium --with-deps
+
+      - name: Run Playwright
+        working-directory: ./automation-testing
+        env:
+          CI: "true"
+          USE_DOCKER_SERVICES: "true"
+          API_BASE_URL: http://127.0.0.1:4003
+          WEB_BASE_URL: http://127.0.0.1:3001
+        run: bun run test:e2e
+
+      - name: Docker Compose down
+        if: always()
+        run: docker compose down -v
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: automation-testing/reports/html
+          if-no-files-found: ignore
+
+  # delete-key values must match stickydisk@v1 key in the e2e job above
+  clean-up:
+    name: Clean-up
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [e2e]
+    if: always()
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Delete sticky disk for automation-testing node_modules
+        uses: useblacksmith/stickydisk-delete@v1
+        with:
+          delete-key: ${{ runner.os }}-counsel-embedded-e2e-bun-${{ hashFiles('automation-testing/bun.lock') }}
+
+      - name: Delete sticky disk for Playwright browsers
+        uses: useblacksmith/stickydisk-delete@v1
+        with:
+          delete-key: ${{ runner.os }}-counsel-embedded-e2e-playwright-${{ hashFiles('automation-testing/package.json', 'automation-testing/bun.lock') }}

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -16,6 +16,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Lint, format, typecheck (automation-testing)
+        working-directory: ./automation-testing
+        run: |
+          bun install --frozen-lockfile
+          bun run lint
+          bun run format:check
+          bun run typecheck
   e2e:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -39,31 +55,10 @@ jobs:
       - name: Fetch secrets from Doppler
         uses: dopplerhq/secrets-fetch-action@v1.3.1
         with:
-          doppler-token: ${{ secrets.DOPPLER_DEV_CI_TOKEN }}
+          doppler-token: ${{ secrets.DOPPLER_CI_TOKEN }}
           doppler-project: ${{ vars.DOPPLER_PROJECT }}
           doppler-config: ${{ vars.DOPPLER_CONFIG }}
           inject-env-vars: true
-
-      - name: Write .env.local for Docker Compose
-        run: |
-          set -euo pipefail
-          umask 077
-          python3 << 'PY'
-          import os
-          import shlex
-
-          keys = (
-              "IRON_SESSION_PASSWORD",
-              "JWT_SECRET",
-              "COUNSEL_WEBHOOK_SECRET",
-              "ACCESS_CODE_CONFIGS",
-          )
-          with open(".env.local", "w", encoding="utf-8") as f:
-              for k in keys:
-                  v = os.environ.get(k)
-                  if v is not None and v != "":
-                      f.write(f"{k}={shlex.quote(v)}\n")
-          PY
 
       - name: Docker Compose up
         run: docker compose up --build -d
@@ -91,16 +86,11 @@ jobs:
 
       - name: Install Playwright Chromium
         working-directory: ./automation-testing
-        run: bunx playwright install chromium --with-deps
+        run: bun run playwright:install:ci
 
       - name: Run Playwright
         working-directory: ./automation-testing
-        env:
-          CI: "true"
-          USE_DOCKER_SERVICES: "true"
-          API_BASE_URL: http://127.0.0.1:4003
-          WEB_BASE_URL: http://127.0.0.1:3001
-        run: bun run test:e2e
+        run: bun run test:e2e:ci
 
       - name: Docker Compose down
         if: always()

--- a/.github/workflows/ci-nextjs-web.yml
+++ b/.github/workflows/ci-nextjs-web.yml
@@ -2,7 +2,6 @@ name: Next.js Web App CI
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
     paths:
       - "web/nextjs/**"
 concurrency:
@@ -15,7 +14,7 @@ jobs:
       run:
         working-directory: ./web/nextjs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci-nodejs-server.yml
+++ b/.github/workflows/ci-nodejs-server.yml
@@ -1,7 +1,6 @@
 name: Node.js Server CI
 on:
   pull_request:
-    branches: [main]
     paths:
       - "server/nodejs/**"
 
@@ -16,7 +15,7 @@ jobs:
       run:
         working-directory: ./server/nodejs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+bun run lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+bun run verify

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Counsel Health Embedded Example Apps
-This repository contains sample code for integrating with Counsel's Embedded Product & APIs. These are intended to be references for code while building your own integrations. 
+
+This repository contains sample code for integrating with Counsel's Embedded Product & APIs. These are intended to be references for code while building your own integrations.
 
 In this repository, you'll find the following sample applications:
+
 - [Mobile](./mobile/) = demo mobile app(s) that use the Counsel WebView
 - [Server](./server/) = demo server that integrates with the Counsel API
 - [Web](./web/) = demo web app(s) that embed the Counsel iFrame
 
+To run the **web + Node** stack with Docker: install the [Doppler CLI](https://docs.doppler.com/docs/install-cli), run **`doppler setup`** at the repo root, then **`./start.sh`**.
 
 Live demo at [https://embedded-demo.counselhealth.com](https://embedded-demo.counselhealth.com).
 Reach out to get an access code. We're here to help at support@counselhealth.com!

--- a/automation-testing/.gitignore
+++ b/automation-testing/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+reports/
+test-results/
+playwright-report/
+playwright/.cache/

--- a/automation-testing/.oxfmtrc.json
+++ b/automation-testing/.oxfmtrc.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "tabWidth": 2,
+  "embeddedSqlTags": ["sql"],
+  "embeddedGraphqlTags": [],
+  "language": "postgresql",
+  "keywordCase": "upper",
+  "expressionWidth": 120,
+  "printWidth": 80,
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "*.sql",
+    "package-lock.json",
+    "bun.lock",
+    ".github/*",
+    ".vscode/*",
+    "*.yaml",
+    "*.yml",
+    "package.json"
+  ]
+}

--- a/automation-testing/.oxlintrc.json
+++ b/automation-testing/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "import"],
+  "rules": {
+    "no-unused-vars": "error"
+  }
+}

--- a/automation-testing/README.md
+++ b/automation-testing/README.md
@@ -1,0 +1,66 @@
+# Embedded example apps — automation (API + UI)
+
+Playwright tests for the demo **Node server** (`server/nodejs`) and the **Next.js** app (`web/nextjs`), without importing either package. Tests use **`API_BASE_URL`** and **`WEB_BASE_URL`** only.
+
+Secrets for local Docker and for optional `doppler run` flows should come from **[Doppler](https://docs.doppler.com/)** (same project/config as [start.sh](../start.sh) at the repo root).
+
+## Environment variables
+
+| Variable              | Purpose                                                                                                                         | Default (local)         |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `API_BASE_URL`        | Demo Express API                                                                                                                | `http://127.0.0.1:4003` |
+| `WEB_BASE_URL`        | Next.js app (browser tests)                                                                                                     | `http://127.0.0.1:3001` |
+| `CI`                  | Set by CI runners                                                                                                               | —                       |
+| `USE_DOCKER_SERVICES` | When `true`, Playwright does not start `webServer` (Compose already up)                                                         | —                       |
+| `PW_START_API_SERVER` | When `true` (and not CI / not `USE_DOCKER_SERVICES`), Playwright starts the Node API from `../server/nodejs` for API tests only | —                       |
+| `E2E_ACCESS_CODE`     | Optional. When set, UI **embedded-flow** tests run a real login (store in Doppler or export locally)                            | —                       |
+
+Doppler should also define **`IRON_SESSION_PASSWORD`**, **`JWT_SECRET`**, **`COUNSEL_WEBHOOK_SECRET`**, and **`ACCESS_CODE_CONFIGS`** for Docker Compose (see [docker-compose.yml](../docker-compose.yml)).
+
+## Doppler (local)
+
+1. Install the [Doppler CLI](https://docs.doppler.com/docs/install-cli) and run **`doppler setup`** at the **repository root** (or copy [doppler.yaml.example](../doppler.yaml.example) to `doppler.yaml` and adjust `project` / `config`).
+2. **Docker (same as CI):** from the repo root run **`./start.sh`**, which downloads secrets into `.env.local` and starts Compose
+3. In another terminal, with containers up:
+   ```bash
+   cd automation-testing
+   bun install
+   bun run playwright:install
+   CI=true USE_DOCKER_SERVICES=true bun run test:e2e
+   ```
+   To pass secrets from Doppler into the Playwright process (e.g. `E2E_ACCESS_CODE`), run:
+   ```bash
+   doppler run -- bun run test:e2e
+   ```
+
+## Run API tests only (no Docker)
+
+The spawned server uses **`NODE_ENV=production`** so the in-memory DB does not run development seeding (which calls Counsel). Use Doppler so `JWT_SECRET`, `COUNSEL_WEBHOOK_SECRET`, and `ACCESS_CODE_CONFIGS` are set:
+
+```bash
+cd automation-testing
+bun install
+bun run playwright:install
+doppler run -- env PW_START_API_SERVER=true bun run test:e2e:api
+```
+
+(Run from repo root if `doppler.yaml` lives there, or set `--project` / `--config` on `doppler run`.)
+
+## CI (GitHub Actions)
+
+The [ci-e2e](../.github/workflows/ci-e2e.yml) workflow uses **`dopplerhq/secrets-fetch-action@v1.3.1`** with **`inject-env-vars: true`**, and Blacksmith **`useblacksmith/stickydisk@v1`** for `automation-testing/node_modules` and **`~/.cache/ms-playwright`** (same pattern as counsel-main’s `ci.yml`). A final **`stickydisk-delete`** job releases those disks; **delete-key** strings must stay in sync with the mount **key** values in the workflow.
+
+Configure the repository with:
+
+- **Secret:** `DOPPLER_DEV_CI_TOKEN` — Doppler service token for the CI config (same pattern as counsel-self-hosted).
+- **Variables:** `DOPPLER_PROJECT` and `DOPPLER_CONFIG` when your token requires explicit project/config (service account tokens).
+
+Secrets injected by the action (including optional `E2E_ACCESS_CODE`) are available to the Playwright step without `doppler run`. Compose still uses a generated **`.env.local`** built from `IRON_SESSION_PASSWORD`, `JWT_SECRET`, `COUNSEL_WEBHOOK_SECRET`, and `ACCESS_CODE_CONFIGS`.
+
+## Scripts
+
+- **`bun run typecheck`** — `tsc --noEmit` for this package.
+
+## Reports
+
+HTML report: `bunx playwright show-report reports/html` after a run.

--- a/automation-testing/README.md
+++ b/automation-testing/README.md
@@ -1,66 +1,73 @@
-# Embedded example apps — automation (API + UI)
+# Automation (API + UI)
 
-Playwright tests for the demo **Node server** (`server/nodejs`) and the **Next.js** app (`web/nextjs`), without importing either package. Tests use **`API_BASE_URL`** and **`WEB_BASE_URL`** only.
+Playwright tests for the demo **Node server** (`server/nodejs`) and **Next.js** app (`web/nextjs`). The suite does not import those packages; it targets them via **`API_BASE_URL`** and **`WEB_BASE_URL`**.
 
-Secrets for local Docker and for optional `doppler run` flows should come from **[Doppler](https://docs.doppler.com/)** (same project/config as [start.sh](../start.sh) at the repo root).
+Use **[Doppler](https://docs.doppler.com/)** for secrets (same project/config as [start.sh](../start.sh) at the repo root).
 
-## Environment variables
+## Quick start (Docker + Doppler)
 
-| Variable              | Purpose                                                                                                                         | Default (local)         |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `API_BASE_URL`        | Demo Express API                                                                                                                | `http://127.0.0.1:4003` |
-| `WEB_BASE_URL`        | Next.js app (browser tests)                                                                                                     | `http://127.0.0.1:3001` |
-| `CI`                  | Set by CI runners                                                                                                               | —                       |
-| `USE_DOCKER_SERVICES` | When `true`, Playwright does not start `webServer` (Compose already up)                                                         | —                       |
-| `PW_START_API_SERVER` | When `true` (and not CI / not `USE_DOCKER_SERVICES`), Playwright starts the Node API from `../server/nodejs` for API tests only | —                       |
-| `E2E_ACCESS_CODE`     | Optional. When set, UI **embedded-flow** tests run a real login (store in Doppler or export locally)                            | —                       |
-
-Doppler should also define **`IRON_SESSION_PASSWORD`**, **`JWT_SECRET`**, **`COUNSEL_WEBHOOK_SECRET`**, and **`ACCESS_CODE_CONFIGS`** for Docker Compose (see [docker-compose.yml](../docker-compose.yml)).
-
-## Doppler (local)
-
-1. Install the [Doppler CLI](https://docs.doppler.com/docs/install-cli) and run **`doppler setup`** at the **repository root** (or copy [doppler.yaml.example](../doppler.yaml.example) to `doppler.yaml` and adjust `project` / `config`).
-2. **Docker (same as CI):** from the repo root run **`./start.sh`**, which downloads secrets into `.env.local` and starts Compose
-3. In another terminal, with containers up:
-   ```bash
-   cd automation-testing
-   bun install
-   bun run playwright:install
-   CI=true USE_DOCKER_SERVICES=true bun run test:e2e
-   ```
-   To pass secrets from Doppler into the Playwright process (e.g. `E2E_ACCESS_CODE`), run:
-   ```bash
-   doppler run -- bun run test:e2e
-   ```
-
-## Run API tests only (no Docker)
-
-The spawned server uses **`NODE_ENV=production`** so the in-memory DB does not run development seeding (which calls Counsel). Use Doppler so `JWT_SECRET`, `COUNSEL_WEBHOOK_SECRET`, and `ACCESS_CODE_CONFIGS` are set:
+1. [Install the Doppler CLI](https://docs.doppler.com/docs/install-cli) and run **`doppler setup`** at the **repo root** (or copy [doppler.yaml.example](../doppler.yaml.example) to `doppler.yaml`).
+2. From the repo root: **`./start.sh`** (writes `.env.local` and starts Compose).
+3. In another terminal:
 
 ```bash
 cd automation-testing
 bun install
 bun run playwright:install
-doppler run -- env PW_START_API_SERVER=true bun run test:e2e:api
+bun run test:e2e
 ```
 
-(Run from repo root if `doppler.yaml` lives there, or set `--project` / `--config` on `doppler run`.)
+`test:e2e` uses **`doppler run`**, so secrets like **`E2E_ACCESS_CODE`** reach Playwright. Doppler finds **`doppler.yaml`** in a parent directory.
 
-## CI (GitHub Actions)
+## Other local runs
 
-The [ci-e2e](../.github/workflows/ci-e2e.yml) workflow uses **`dopplerhq/secrets-fetch-action@v1.3.1`** with **`inject-env-vars: true`**, and Blacksmith **`useblacksmith/stickydisk@v1`** for `automation-testing/node_modules` and **`~/.cache/ms-playwright`** (same pattern as counsel-main’s `ci.yml`). A final **`stickydisk-delete`** job releases those disks; **delete-key** strings must stay in sync with the mount **key** values in the workflow.
+Start the **API** and **web** yourself (e.g. repo root **`./start.sh`**, or **`docker compose up`**, or run **`server/nodejs`** and **`web/nextjs`** dev servers on the URLs in **`API_BASE_URL`** / **`WEB_BASE_URL`**). For API-only runs you still need a reachable server with valid `JWT_SECRET`, `COUNSEL_WEBHOOK_SECRET`, and `ACCESS_CODE_CONFIGS` (via Doppler or env).
 
-Configure the repository with:
+```bash
+cd automation-testing
+bun install && bun run playwright:install
+bun run test:e2e:api   # or test:e2e:ui / test:e2e
+```
 
-- **Secret:** `DOPPLER_DEV_CI_TOKEN` — Doppler service token for the CI config (same pattern as counsel-self-hosted).
-- **Variables:** `DOPPLER_PROJECT` and `DOPPLER_CONFIG` when your token requires explicit project/config (service account tokens).
+## Environment
 
-Secrets injected by the action (including optional `E2E_ACCESS_CODE`) are available to the Playwright step without `doppler run`. Compose still uses a generated **`.env.local`** built from `IRON_SESSION_PASSWORD`, `JWT_SECRET`, `COUNSEL_WEBHOOK_SECRET`, and `ACCESS_CODE_CONFIGS`.
+| Variable          | Role                                   | Default                 |
+| ----------------- | -------------------------------------- | ----------------------- |
+| `API_BASE_URL`    | Express API (must already be running)  | `http://127.0.0.1:4003` |
+| `WEB_BASE_URL`    | Next.js (must already be running)      | `http://127.0.0.1:3001` |
+| `CI`              | Set by CI (workers, retries, headless) | —                       |
+| `HEADLESS`        | `true` → headless browser (local UI)   | —                       |
+| `E2E_ACCESS_CODE` | Required for embedded-flow login test  | —                       |
+
+## CI
+
+Workflow: [.github/workflows/ci-e2e.yml](../.github/workflows/ci-e2e.yml). It fetches secrets with **`dopplerhq/secrets-fetch-action`** (**`inject-env-vars: true`** puts them on the job environment). **`docker compose up`** starts the stack; Compose resolves **`${VAR}`** in [docker-compose.yml](../docker-compose.yml) from that environment first (so web/server containers receive Doppler values). Playwright (**`test:e2e:ci`**) only runs tests against those URLs and sees the same job env (e.g. **`E2E_ACCESS_CODE`**). Blacksmith **stickydisk** caches `automation-testing/node_modules` and `~/.cache/ms-playwright`; the cleanup job’s **delete-key** values must match the mount keys in the workflow.
+
+**Repo settings:** secret **`DOPPLER_CI_TOKEN`**; variables **`DOPPLER_PROJECT`** and **`DOPPLER_CONFIG`** if your token needs them.
+
+**Reproduce CI locally** (Compose on 3001 / 4003, from repo root):
+
+```bash
+docker compose up --build -d
+cd automation-testing
+bun run playwright:install:ci
+bun run test:e2e:ci
+```
+
+With Doppler in the shell, exported secrets override for the same variable names. Without Doppler, UI tests that need a real access code still require **`E2E_ACCESS_CODE`** (e.g. `export E2E_ACCESS_CODE=...` before **`bun run test:e2e:ci`**).
+
+The **`:ci`** scripts use inline `VAR=value` (Unix-friendly). On Windows, use Git Bash, WSL, or set the same variables yourself.
 
 ## Scripts
 
-- **`bun run typecheck`** — `tsc --noEmit` for this package.
+| Script                                             | What it does                                                                 |
+| -------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `test:e2e`, `test:e2e:api`, `test:e2e:ui`          | `doppler run` + Playwright.                                                  |
+| `test:e2e:ci`, `test:e2e:api:ci`, `test:e2e:ui:ci` | CI-style env and Compose URLs; no `doppler run`.                             |
+| `playwright:install` / `playwright:install:ci`     | Chromium locally / with `--with-deps` (CI).                                  |
+| `lint` / `format` / `format:check`                 | **oxlint** / **oxfmt** (same toolchain as `server/nodejs` and `web/nextjs`). |
+| `typecheck`                                        | `tsc --noEmit`.                                                              |
 
 ## Reports
 
-HTML report: `bunx playwright show-report reports/html` after a run.
+After a run: **`bunx playwright show-report reports/html`**.

--- a/automation-testing/api/health.spec.ts
+++ b/automation-testing/api/health.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("demo server health", () => {
+  test("GET /health returns ok", async ({ request }) => {
+    const response = await request.get("/health");
+    await expect(response).toBeOK();
+    const body = await response.json();
+    expect(body).toEqual({ message: "ok" });
+  });
+});

--- a/automation-testing/api/signUp.spec.ts
+++ b/automation-testing/api/signUp.spec.ts
@@ -42,7 +42,9 @@ test.describe("POST /user/signUp", () => {
     const body = await response.json();
     expect(body).toMatchObject({
       errors: {
-        message: expect.stringMatching(/Invalid request body|Missing request body/),
+        message: expect.stringMatching(
+          /Invalid request body|Missing request body/
+        ),
       },
     });
   });

--- a/automation-testing/api/signUp.spec.ts
+++ b/automation-testing/api/signUp.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+
+test.describe("POST /user/signUp", () => {
+  test("rejects unknown access code without calling Counsel", async ({
+    request,
+  }) => {
+    const response = await request.post("/user/signUp", {
+      data: {
+        accessCode: "ZZZZZZ",
+        userId: randomUUID(),
+      },
+    });
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body).toEqual({ error: "Invalid access code" });
+  });
+
+  test("rejects invalid body when accessCode length is not 6", async ({
+    request,
+  }) => {
+    const response = await request.post("/user/signUp", {
+      data: {
+        accessCode: "NO",
+        userId: randomUUID(),
+      },
+    });
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      errors: {
+        message: "Invalid request body",
+      },
+    });
+  });
+
+  test("rejects empty JSON body", async ({ request }) => {
+    const response = await request.post("/user/signUp", {
+      data: {},
+    });
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      errors: {
+        message: expect.stringMatching(/Invalid request body|Missing request body/),
+      },
+    });
+  });
+});

--- a/automation-testing/bun.lock
+++ b/automation-testing/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@counsel/embedded-automation-testing",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "@types/node": "^22.10.0",
+        "typescript": "^6.0.2",
+      },
+    },
+  },
+  "packages": {
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
+    "@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/automation-testing/bun.lock
+++ b/automation-testing/bun.lock
@@ -6,21 +6,105 @@
       "name": "@counsel/embedded-automation-testing",
       "devDependencies": {
         "@playwright/test": "^1.49.0",
-        "@types/node": "^22.10.0",
+        "@types/node": "^22.0.0",
+        "oxfmt": "^0.43.0",
+        "oxlint": "^1.58.0",
         "typescript": "^6.0.2",
       },
     },
   },
   "packages": {
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.43.0", "", { "os": "android", "cpu": "arm" }, "sha512-CgU2s+/9hHZgo0IxVxrbMPrMj+tJ6VM3mD7Mr/4oiz4FNTISLoCvRmB5nk4wAAle045RtRjd86m673jwPyb1OQ=="],
+
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.43.0", "", { "os": "android", "cpu": "arm64" }, "sha512-T9OfRwjA/EdYxAqbvR7TtqLv5nIrwPXuCtTwOHtS7aR9uXyn74ZYgzgTo6/ZwvTq9DY4W+DsV09hB2EXgn9EbA=="],
+
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.43.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-o3i49ZUSJWANzXMAAVY1wnqb65hn4JVzwlRQ5qfcwhRzIA8lGVaud31Q3by5ALHPrksp5QEaKCQF9aAS3TXpZA=="],
+
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.43.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-vWECzzCFkb0kK6jaHjbtC5sC3adiNWtqawFCxhpvsWlzVeKmv5bNvkB4nux+o4JKWTpHCM57NDK/MeXt44txmA=="],
+
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.43.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-rgz8JpkKiI/umOf7fl9gwKyQasC8bs5SYHy6g7e4SunfLBY3+8ATcD5caIg8KLGEtKFm5ujKaH8EfjcmnhzTLg=="],
+
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.43.0", "", { "os": "linux", "cpu": "arm" }, "sha512-nWYnF3vIFzT4OM1qL/HSf1Yuj96aBuKWSaObXHSWliwAk2rcj7AWd6Lf7jowEBQMo4wCZVnueIGw/7C4u0KTBQ=="],
+
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.43.0", "", { "os": "linux", "cpu": "arm" }, "sha512-sFg+NWJbLfupYTF4WELHAPSnLPOn1jiDZ33Z1jfDnTaA+cC3iB35x0FMMZTFdFOz3icRIArncwCcemJFGXu6TQ=="],
+
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.43.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-MelWqv68tX6wZEILDrTc9yewiGXe7im62+5x0bNXlCYFOZdA+VnYiJfAihbROsZ5fm90p9C3haFrqjj43XnlAA=="],
+
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.43.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ROaWfYh+6BSJ1Arwy5ujijTlwnZetxDxzBpDc1oBR4d7rfrPBqzeyjd5WOudowzQUgyavl2wEpzn1hw3jWcqLA=="],
+
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.43.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-PJRs/uNxmFipJJ8+SyKHh7Y7VZIKQicqrrBzvfyM5CtKi8D7yZKTwUOZV3ffxmiC2e7l1SDJpkBEOyue5NAFsg=="],
+
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.43.0", "", { "os": "linux", "cpu": "none" }, "sha512-j6biGAgzIhj+EtHXlbNumvwG7XqOIdiU4KgIWRXAEj/iUbHKukKW8eXa4MIwpQwW1YkxovduKtzEAPnjlnAhVQ=="],
+
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.43.0", "", { "os": "linux", "cpu": "none" }, "sha512-RYWxAcslKxvy7yri24Xm9cmD0RiANaiEPs007EFG6l9h1ChM69Q5SOzACaCoz4Z9dEplnhhneeBaTWMEdpgIbA=="],
+
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.43.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-DT6Q8zfQQy3jxpezAsBACEHNUUixKSYTwdXeXojNHe4DQOoxjPdjr3Szu6BRNjxLykZM/xMNmp9ElOIyDppwtw=="],
+
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.43.0", "", { "os": "linux", "cpu": "x64" }, "sha512-R8Yk7iYcuZORXmCfFZClqbDxRZgZ9/HEidUuBNdoX8Ptx07cMePnMVJ/woB84lFIDjh2ROHVaOP40Ds3rBXFqg=="],
+
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.43.0", "", { "os": "linux", "cpu": "x64" }, "sha512-F2YYqyvnQNvi320RWZNAvsaWEHwmW3k4OwNJ1hZxRKXupY63expbBaNp6jAgvYs7y/g546vuQnGHQuCBhslhLQ=="],
+
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.43.0", "", { "os": "none", "cpu": "arm64" }, "sha512-OE6TdietLXV3F6c7pNIhx/9YC1/2YFwjU9DPc/fbjxIX19hNIaP1rS0cFjCGJlGX+cVJwIKWe8Mos+LdQ1yAJw=="],
+
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.43.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-0nWK6a7pGkbdoypfVicmV9k/N1FwjPZENoqhlTU+5HhZnAhpIO3za30nEE33u6l6tuy9OVfpdXUqxUgZ+4lbZw=="],
+
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.43.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-9aokTR4Ft+tRdvgN/pKzSkVy2ksc4/dCpDm9L/xFrbIw0yhLtASLbvoG/5WOTUh/BRPPnfGTsWznEqv0dlOmhA=="],
+
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.43.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4bPgdQux2ZLWn3bf2TTXXMHcJB4lenmuxrLqygPmvCJ104Yqzj1UctxSRzR31TiJ4MLaG22RK8dUsVpJtrCz5g=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.58.0", "", { "os": "android", "cpu": "arm" }, "sha512-1T7UN3SsWWxpWyWGn1cT3ASNJOo+pI3eUkmEl7HgtowapcV8kslYpFQcYn431VuxghXakPNlbjRwhqmR37PFOg=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.58.0", "", { "os": "android", "cpu": "arm64" }, "sha512-GryzujxuiRv2YFF7bRy8mKcxlbuAN+euVUtGJt9KKbLT8JBUIosamVhcthLh+VEr6KE6cjeVMAQxKAzJcoN7dg=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.58.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7/bRSJIwl4GxeZL9rPZ11anNTyUO9epZrfEJH/ZMla3+/gbQ6xZixh9nOhsZ0QwsTW7/5J2A/fHbD1udC5DQQA=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.58.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EqdtJSiHweS2vfILNrpyJ6HUwpEq2g7+4Zx1FPi4hu3Hu7tC3znF6ufbXO8Ub2LD4mGgznjI7kSdku9NDD1Mkg=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.58.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-VQt5TH4M42mY20F545G637RKxV/yjwVtKk2vfXuazfReSIiuvWBnv+FVSvIV5fKVTJNjt3GSJibh6JecbhGdBw=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.58.0", "", { "os": "linux", "cpu": "arm" }, "sha512-fBYcj4ucwpAtjJT3oeBdFBYKvNyjRSK+cyuvBOTQjh0jvKp4yeA4S/D0IsCHus/VPaNG5L48qQkh+Vjy3HL2/Q=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.58.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0BeuFfwlUHlJ1xpEdSD1YO3vByEFGPg36uLjK1JgFaxFb4W6w17F8ET8sz5cheZ4+x5f2xzdnRrrWv83E3Yd8g=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.58.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-TXlZgnPTlxrQzxG9ZXU7BNwx1Ilrr17P3GwZY0If2EzrinqRH3zXPc3HrRcBJgcsoZNMuNL5YivtkJYgp467UQ=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.58.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zSoYRo5dxHLcUx93Stl2hW3hSNjPt99O70eRVWt5A1zwJ+FPjeCCANCD2a9R4JbHsdcl11TIQOjyigcRVOH2mw=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.58.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NQ0U/lqxH2/VxBYeAIvMNUK1y0a1bJ3ZicqkF2c6wfakbEciP9jvIE4yNzCFpZaqeIeRYaV7AVGqEO1yrfVPjA=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.58.0", "", { "os": "linux", "cpu": "none" }, "sha512-X9J+kr3gIC9FT8GuZt0ekzpNUtkBVzMVU4KiKDSlocyQuEgi3gBbXYN8UkQiV77FTusLDPsovjo95YedHr+3yg=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.58.0", "", { "os": "linux", "cpu": "none" }, "sha512-CDze3pi1OO3Wvb/QsXjmLEY4XPKGM6kIo82ssNOgmcl1IdndF9VSGAE38YLhADWmOac7fjqhBw82LozuUVxD0Q=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.58.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-b/89glbxFaEAcA6Uf1FvCNecBJEgcUTsV1quzrqXM/o4R1M4u+2KCVuyGCayN2UpsRWtGGLb+Ver0tBBpxaPog=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.58.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.58.0", "", { "os": "linux", "cpu": "x64" }, "sha512-hr6FNvmcAXiH+JxSvaJ4SJ1HofkdqEElXICW9sm3/Rd5eC3t7kzvmLyRAB3NngKO2wzXRCAm4Z/mGWfrsS4X8w=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.58.0", "", { "os": "none", "cpu": "arm64" }, "sha512-R+O368VXgRql1K6Xar+FEo7NEwfo13EibPMoTv3sesYQedRXd6m30Dh/7lZMxnrQVFfeo4EOfYIP4FpcgWQNHg=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.58.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q0FZiAY/3c4YRj4z3h9K1PgaByrifrfbBoODSeX7gy97UtB7pySPUQfC2B/GbxWU6k7CzQrRy5gME10PltLAFQ=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.58.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-Y8FKBABrSPp9H0QkRLHDHOSUgM/309a3IvOVgPcVxYcX70wxJrk608CuTg7w+C6vEd724X5wJoNkBcGYfH7nNQ=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.58.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg=="],
+
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
-    "@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "oxfmt": ["oxfmt@0.43.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.43.0", "@oxfmt/binding-android-arm64": "0.43.0", "@oxfmt/binding-darwin-arm64": "0.43.0", "@oxfmt/binding-darwin-x64": "0.43.0", "@oxfmt/binding-freebsd-x64": "0.43.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.43.0", "@oxfmt/binding-linux-arm-musleabihf": "0.43.0", "@oxfmt/binding-linux-arm64-gnu": "0.43.0", "@oxfmt/binding-linux-arm64-musl": "0.43.0", "@oxfmt/binding-linux-ppc64-gnu": "0.43.0", "@oxfmt/binding-linux-riscv64-gnu": "0.43.0", "@oxfmt/binding-linux-riscv64-musl": "0.43.0", "@oxfmt/binding-linux-s390x-gnu": "0.43.0", "@oxfmt/binding-linux-x64-gnu": "0.43.0", "@oxfmt/binding-linux-x64-musl": "0.43.0", "@oxfmt/binding-openharmony-arm64": "0.43.0", "@oxfmt/binding-win32-arm64-msvc": "0.43.0", "@oxfmt/binding-win32-ia32-msvc": "0.43.0", "@oxfmt/binding-win32-x64-msvc": "0.43.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-KTYNG5ISfHSdmeZ25Xzb3qgz9EmQvkaGAxgBY/p38+ZiAet3uZeu7FnMwcSQJg152Qwl0wnYAxDc+Z/H6cvrwA=="],
+
+    "oxlint": ["oxlint@1.58.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.58.0", "@oxlint/binding-android-arm64": "1.58.0", "@oxlint/binding-darwin-arm64": "1.58.0", "@oxlint/binding-darwin-x64": "1.58.0", "@oxlint/binding-freebsd-x64": "1.58.0", "@oxlint/binding-linux-arm-gnueabihf": "1.58.0", "@oxlint/binding-linux-arm-musleabihf": "1.58.0", "@oxlint/binding-linux-arm64-gnu": "1.58.0", "@oxlint/binding-linux-arm64-musl": "1.58.0", "@oxlint/binding-linux-ppc64-gnu": "1.58.0", "@oxlint/binding-linux-riscv64-gnu": "1.58.0", "@oxlint/binding-linux-riscv64-musl": "1.58.0", "@oxlint/binding-linux-s390x-gnu": "1.58.0", "@oxlint/binding-linux-x64-gnu": "1.58.0", "@oxlint/binding-linux-x64-musl": "1.58.0", "@oxlint/binding-openharmony-arm64": "1.58.0", "@oxlint/binding-win32-arm64-msvc": "1.58.0", "@oxlint/binding-win32-ia32-msvc": "1.58.0", "@oxlint/binding-win32-x64-msvc": "1.58.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-t4s9leczDMqlvOSjnbCQe7gtoLkWgBGZ7sBdCJ9EOj5IXFSG/X7OAzK4yuH4iW+4cAYe8kLFbC8tuYMwWZm+Cg=="],
 
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
+    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 

--- a/automation-testing/package.json
+++ b/automation-testing/package.json
@@ -3,15 +3,25 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "test:e2e": "bunx playwright test",
-    "test:e2e:api": "bunx playwright test --project=api",
-    "test:e2e:ui": "bunx playwright test --project=ui",
+    "test:e2e": "doppler run -- bunx playwright test",
+    "test:e2e:api": "doppler run -- bunx playwright test --project=api",
+    "test:e2e:ui": "doppler run -- bunx playwright test --project=ui",
+    "test:e2e:ci": "CI=true API_BASE_URL=http://127.0.0.1:4003 WEB_BASE_URL=http://127.0.0.1:3001 bunx playwright test",
+    "test:e2e:api:ci": "CI=true API_BASE_URL=http://127.0.0.1:4003 WEB_BASE_URL=http://127.0.0.1:3001 bunx playwright test --project=api",
+    "test:e2e:ui:ci": "CI=true API_BASE_URL=http://127.0.0.1:4003 WEB_BASE_URL=http://127.0.0.1:3001 bunx playwright test --project=ui",
     "playwright:install": "bunx playwright install chromium",
-    "typecheck": "bunx tsc --noEmit"
+    "playwright:install:ci": "bunx playwright install chromium --with-deps",
+    "lint": "oxlint api/ ui/ playwright.config.ts",
+    "format": "oxfmt 'api/**/*.ts' 'ui/**/*.ts' playwright.config.ts",
+    "format:check": "oxfmt --check 'api/**/*.ts' 'ui/**/*.ts' playwright.config.ts",
+    "typecheck": "bunx tsc --noEmit",
+    "verify": "bun run lint && bun run format:check && bun run typecheck"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",
-    "@types/node": "^22.10.0",
+    "@types/node": "^22.0.0",
+    "oxfmt": "^0.43.0",
+    "oxlint": "^1.58.0",
     "typescript": "^6.0.2"
   },
   "packageManager": "bun@1.3.11"

--- a/automation-testing/package.json
+++ b/automation-testing/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@counsel/embedded-automation-testing",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test:e2e": "bunx playwright test",
+    "test:e2e:api": "bunx playwright test --project=api",
+    "test:e2e:ui": "bunx playwright test --project=ui",
+    "playwright:install": "bunx playwright install chromium",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.10.0",
+    "typescript": "^6.0.2"
+  },
+  "packageManager": "bun@1.3.11"
+}

--- a/automation-testing/playwright.config.ts
+++ b/automation-testing/playwright.config.ts
@@ -1,45 +1,6 @@
-import path from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 
-const repoRoot = path.join(__dirname, "..");
-
 const isCi = process.env["CI"] === "true";
-const useDockerServices = process.env["USE_DOCKER_SERVICES"] === "true";
-const startApiServer = process.env["PW_START_API_SERVER"] === "true";
-
-const defaultAccessCodeConfigs = JSON.stringify({
-  TST001: {
-    client: "local",
-    apiUrl: "https://example.com",
-    userType: "main",
-    apiKey: "local-placeholder-not-used-for-unknown-codes",
-  },
-});
-
-const webServer =
-  !isCi && !useDockerServices && startApiServer
-    ? {
-        command: "bun src/index.ts",
-        cwd: path.join(repoRoot, "server", "nodejs"),
-        url: "http://127.0.0.1:4003/health",
-        reuseExistingServer: true,
-        timeout: 120_000,
-        env: {
-          ...process.env,
-          PORT: "4003",
-          // production skips in-memory seeding that calls Counsel on startup (see server db.ts)
-          NODE_ENV: "production",
-          JWT_SECRET:
-            process.env["JWT_SECRET"] ??
-            "01234567890123456789012345678901",
-          COUNSEL_WEBHOOK_SECRET:
-            process.env["COUNSEL_WEBHOOK_SECRET"] ??
-            "whsec_test_webhook_secret_minimum_length_ok",
-          ACCESS_CODE_CONFIGS:
-            process.env["ACCESS_CODE_CONFIGS"] ?? defaultAccessCodeConfigs,
-        },
-      }
-    : undefined;
 
 export default defineConfig({
   timeout: 2 * 60 * 1000,
@@ -48,7 +9,6 @@ export default defineConfig({
   reporter: [["html", { outputFolder: "reports/html" }], ["list"]],
   workers: isCi ? 2 : 5,
   testDir: ".",
-  webServer,
   projects: [
     {
       name: "api",

--- a/automation-testing/playwright.config.ts
+++ b/automation-testing/playwright.config.ts
@@ -1,0 +1,81 @@
+import path from "node:path";
+import { defineConfig, devices } from "@playwright/test";
+
+const repoRoot = path.join(__dirname, "..");
+
+const isCi = process.env["CI"] === "true";
+const useDockerServices = process.env["USE_DOCKER_SERVICES"] === "true";
+const startApiServer = process.env["PW_START_API_SERVER"] === "true";
+
+const defaultAccessCodeConfigs = JSON.stringify({
+  TST001: {
+    client: "local",
+    apiUrl: "https://example.com",
+    userType: "main",
+    apiKey: "local-placeholder-not-used-for-unknown-codes",
+  },
+});
+
+const webServer =
+  !isCi && !useDockerServices && startApiServer
+    ? {
+        command: "bun src/index.ts",
+        cwd: path.join(repoRoot, "server", "nodejs"),
+        url: "http://127.0.0.1:4003/health",
+        reuseExistingServer: true,
+        timeout: 120_000,
+        env: {
+          ...process.env,
+          PORT: "4003",
+          // production skips in-memory seeding that calls Counsel on startup (see server db.ts)
+          NODE_ENV: "production",
+          JWT_SECRET:
+            process.env["JWT_SECRET"] ??
+            "01234567890123456789012345678901",
+          COUNSEL_WEBHOOK_SECRET:
+            process.env["COUNSEL_WEBHOOK_SECRET"] ??
+            "whsec_test_webhook_secret_minimum_length_ok",
+          ACCESS_CODE_CONFIGS:
+            process.env["ACCESS_CODE_CONFIGS"] ?? defaultAccessCodeConfigs,
+        },
+      }
+    : undefined;
+
+export default defineConfig({
+  timeout: 2 * 60 * 1000,
+  fullyParallel: true,
+  expect: { timeout: 10_000 },
+  reporter: [["html", { outputFolder: "reports/html" }], ["list"]],
+  workers: isCi ? 2 : 5,
+  testDir: ".",
+  webServer,
+  projects: [
+    {
+      name: "api",
+      testMatch: "api/**/*.spec.ts",
+      retries: isCi ? 1 : 0,
+      use: {
+        baseURL: process.env["API_BASE_URL"] ?? "http://127.0.0.1:4003",
+      },
+    },
+    {
+      name: "ui",
+      testMatch: "ui/**/*.spec.ts",
+      retries: isCi ? 1 : 0,
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: process.env["WEB_BASE_URL"] ?? "http://127.0.0.1:3001",
+        actionTimeout: 20_000,
+        navigationTimeout: 30_000,
+        headless: isCi || process.env["HEADLESS"] === "true",
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.81",
+        permissions: ["clipboard-read", "clipboard-write"],
+        testIdAttribute: "data-testid",
+        trace: "retain-on-failure",
+        screenshot: "only-on-failure",
+        video: "retain-on-failure",
+      },
+    },
+  ],
+});

--- a/automation-testing/tsconfig.json
+++ b/automation-testing/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["api/**/*.ts", "ui/**/*.ts", "playwright.config.ts"]
+}

--- a/automation-testing/ui/embedded-flow.spec.ts
+++ b/automation-testing/ui/embedded-flow.spec.ts
@@ -1,13 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const accessCode = process.env["E2E_ACCESS_CODE"];
 
 test.describe("embedded flow", () => {
-  test.skip(
-    !accessCode || accessCode.length !== 6,
-    "Set E2E_ACCESS_CODE (6 chars) to run full UI flow against a real Counsel-backed server"
-  );
-
   test("login, dashboard, chat iframe", async ({ page }) => {
     await page.goto("/login");
 
@@ -17,7 +12,9 @@ test.describe("embedded flow", () => {
     await expect(page).toHaveURL(/\/dashboard/);
     await expect(
       page.getByRole("heading", { name: "Welcome back!" })
-    ).toBeVisible({ timeout: 15_000 });
+    ).toBeVisible({
+      timeout: 15_000,
+    });
 
     await page.goto("/dashboard/chat");
 

--- a/automation-testing/ui/embedded-flow.spec.ts
+++ b/automation-testing/ui/embedded-flow.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+const accessCode = process.env["E2E_ACCESS_CODE"];
+
+test.describe("embedded flow", () => {
+  test.skip(
+    !accessCode || accessCode.length !== 6,
+    "Set E2E_ACCESS_CODE (6 chars) to run full UI flow against a real Counsel-backed server"
+  );
+
+  test("login, dashboard, chat iframe", async ({ page }) => {
+    await page.goto("/login");
+
+    await page.getByLabel("Access Code").fill(accessCode!);
+    await page.getByRole("button", { name: "Login" }).click();
+
+    await expect(page).toHaveURL(/\/dashboard/);
+    await expect(
+      page.getByRole("heading", { name: "Welcome back!" })
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.goto("/dashboard/chat");
+
+    const frame = page.locator("iframe").first();
+    await expect(frame).toBeVisible({ timeout: 30_000 });
+    const src = await frame.getAttribute("src");
+    expect(src).toBeTruthy();
+    expect(src).toMatch(/^https?:\/\//);
+  });
+});

--- a/automation-testing/ui/login-smoke.spec.ts
+++ b/automation-testing/ui/login-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.describe("login smoke", () => {
   test("unknown access code shows error and stays on login", async ({

--- a/automation-testing/ui/login-smoke.spec.ts
+++ b/automation-testing/ui/login-smoke.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("login smoke", () => {
+  test("unknown access code shows error and stays on login", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+
+    await page.getByLabel("Access Code").fill("ZZZZZZ");
+    await page.getByRole("button", { name: "Login" }).click();
+
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByText("Invalid access code")).toBeVisible();
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,193 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "counsel-embedded-example-apps",
+      "devDependencies": {
+        "concurrently": "^9.2.1",
+        "husky": "^9.1.7",
+        "lint-staged": "^15.4.3",
+      },
+    },
+  },
+  "packages": {
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
+    "get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lint-staged": ["lint-staged@15.5.2", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^13.1.0", "debug": "^4.4.0", "execa": "^8.0.1", "lilconfig": "^3.1.3", "listr2": "^8.2.5", "micromatch": "^4.0.8", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.7.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w=="],
+
+    "listr2": ["listr2@8.3.3", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ=="],
+
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
+
+    "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
+
+    "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
+
+    "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "lint-staged/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
+    "log-update/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "cli-truncate/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,40 @@
+# Docker Compose for embedded demo (Next.js web + Node API).
+#
+# Container env comes from the `environment:` list below. Values are filled at
+# `docker compose` parse time via variable substitution: `${VAR}` is taken from the current shell environment first.
+# So Doppler-injected CI env, or `doppler run` locally, supplies real secrets into
+# containers the same way writing a temp `.env` file from `os.environ` did—without
+# an intermediate env file for Compose.
+#
+# `.env.local` is only for Next/Node local dev (`start.sh` copies into web/nextjs
+# and server/nodejs); Compose does not read it.
+
 services:
   web:
-    env_file:
-      - ./.env.local
     build:
       context: ./web/nextjs
       dockerfile: Dockerfile
     ports:
-      - '3001:3001'
-    environment: 
+      - "3001:3001"
+    environment:
       - NODE_ENV=production
       - PORT=3001
       - SERVER_HOST=http://server:4003
-    networks:
-      - shared
+      - IRON_SESSION_PASSWORD=${IRON_SESSION_PASSWORD}
+      # Reachable from inside the web container (not localhost unless Counsel is in Compose)
+      - COUNSEL_API_URL=${COUNSEL_API_URL}
+      - COUNSEL_API_HOST=${COUNSEL_API_HOST}
 
   server:
-    env_file:
-      - ./.env.local
     build:
       context: ./server/nodejs
       dockerfile: Dockerfile
     ports:
-      - '4003:4003'
-    environment: 
+      - "4003:4003"
+    environment:
       - NODE_ENV=production
       - PORT=4003
-    networks:
-      - shared
-
-networks:
-  shared:
+      - JWT_SECRET=${JWT_SECRET}
+      - COUNSEL_WEBHOOK_SECRET=${COUNSEL_WEBHOOK_SECRET}
+      - COUNSEL_PRIVATE_KEY_PEM=${COUNSEL_PRIVATE_KEY_PEM}
+      - ACCESS_CODE_CONFIGS=${ACCESS_CODE_CONFIGS}

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,56 @@
+import path from "node:path";
+
+/**
+ * lint-staged v15 passes absolute paths to function tasks (see generateTasks:
+ * path.resolve(cwd, file)). Normalize to cwd-relative POSIX paths before
+ * stripping the package directory prefix.
+ *
+ * @param {string[]} files
+ * @param {string} prefix repo-relative directory prefix (no trailing slash)
+ */
+function stripPrefix(files, prefix) {
+  const p = `${prefix}/`;
+  const cwd = process.cwd();
+  return files.map((f) => {
+    const abs = path.isAbsolute(f) ? f : path.resolve(cwd, f);
+    const rel = path.relative(cwd, abs).split(path.sep).join("/");
+    return rel.startsWith(p) ? rel.slice(p.length) : rel;
+  });
+}
+
+/** @param {string} arg */
+function shellQuote(arg) {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/** @param {string[]} files @param {string} prefix */
+function quotedRelativePaths(files, prefix) {
+  return stripPrefix(files, prefix).map(shellQuote).join(" ");
+}
+
+export default {
+  "web/nextjs/**/*.{ts,tsx}": (files) => {
+    if (files.length === 0) return [];
+    const q = quotedRelativePaths(files, "web/nextjs");
+    return [
+      `cd web/nextjs && bunx oxfmt --write ${q}`,
+      `cd web/nextjs && bunx oxlint ${q}`,
+    ];
+  },
+  "server/nodejs/**/*.ts": (files) => {
+    if (files.length === 0) return [];
+    const q = quotedRelativePaths(files, "server/nodejs");
+    return [
+      `cd server/nodejs && bunx oxfmt --write ${q}`,
+      `cd server/nodejs && bunx oxlint ${q}`,
+    ];
+  },
+  "automation-testing/**/*.{ts,tsx}": (files) => {
+    if (files.length === 0) return [];
+    const q = quotedRelativePaths(files, "automation-testing");
+    return [
+      `cd automation-testing && bunx oxfmt --write ${q}`,
+      `cd automation-testing && bunx oxlint ${q}`,
+    ];
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "counsel-embedded-example-apps",
+  "private": true,
+  "scripts": {
+    "prepare": "husky",
+    "lint-staged": "lint-staged",
+    "verify": "concurrently -n web,server,automation -c auto \"bun run --cwd web/nextjs verify\" \"bun run --cwd server/nodejs verify\" \"bun run --cwd automation-testing verify\""
+  },
+  "devDependencies": {
+    "concurrently": "^9.2.1",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.4.3"
+  },
+  "packageManager": "bun@1.3.11"
+}

--- a/server/nodejs/package.json
+++ b/server/nodejs/package.json
@@ -16,6 +16,7 @@
     "dev": "NODE_ENV=development doppler run -- bun --hot src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "verify": "bun run lint && bun run test && bun run typecheck && bun run compile",
     "ci": "bun install --production && bun run compile",
     "healthcheck": "sh ./healthcheck.sh"
   },

--- a/start.sh
+++ b/start.sh
@@ -4,8 +4,7 @@
 # - web: nextjs
 # - server: nodejs
 #
-# Requires: Doppler CLI and `doppler setup` at the repo root (or doppler.yaml).
-# See doppler.yaml.example and automation-testing/README.md.
+# Requires: Doppler CLI and `doppler setup` at the repo root.
 
 set -euo pipefail
 
@@ -18,9 +17,9 @@ echo "🔄 Copying .env.local to server/nodejs/.env.local"
 cp .env.local server/nodejs/.env.local
 
 echo "🐳 Stopping any existing containers..."
-docker compose down
+docker compose --env-file .env.local down
 
 echo "🚀 Starting services..."
-docker compose up --build
+doppler run -- docker compose --env-file .env.local up --build
 
 echo "✅ Services started successfully!"

--- a/start.sh
+++ b/start.sh
@@ -3,8 +3,11 @@
 ## Startup docker compose with the following services:
 # - web: nextjs
 # - server: nodejs
+#
+# Requires: Doppler CLI and `doppler setup` at the repo root (or doppler.yaml).
+# See doppler.yaml.example and automation-testing/README.md.
 
-set -e  # Exit on any error
+set -euo pipefail
 
 echo "🔐 Downloading secrets from Doppler..."
 doppler secrets download --format=env-no-quotes --no-file > .env.local
@@ -15,9 +18,9 @@ echo "🔄 Copying .env.local to server/nodejs/.env.local"
 cp .env.local server/nodejs/.env.local
 
 echo "🐳 Stopping any existing containers..."
-docker-compose down
+docker compose down
 
 echo "🚀 Starting services..."
-docker-compose up --build
+docker compose up --build
 
-echo "✅ Services started successfully!" 
+echo "✅ Services started successfully!"

--- a/web/nextjs/.env.example
+++ b/web/nextjs/.env.example
@@ -1,6 +1,10 @@
 # This is the password for the iron session.
 IRON_SESSION_PASSWORD=
 
-# The server HOST, defaults to localhost:4003 if not set
+# Demo Node API (embedded server). Defaults to http://localhost:4003
 SERVER_HOST=
+
+# Counsel API base URL for the JWT signedAppUrl flow. Use COUNSEL_API_URL or COUNSEL_API_HOST.
+# In Docker, prefer http://host.docker.internal:<port> if Counsel runs on your machine.
+COUNSEL_API_URL=
 

--- a/web/nextjs/next.config.ts
+++ b/web/nextjs/next.config.ts
@@ -4,6 +4,11 @@ import "./src/envConfig";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // Turbopack workspace root (silences multi-lockfile warning). Use cwd so the
+  // compiled config avoids import.meta / mixed ESM-CJS issues in next.config.ts.
+  turbopack: {
+    root: process.cwd(),
+  },
 };
 
 export default nextConfig;

--- a/web/nextjs/package.json
+++ b/web/nextjs/package.json
@@ -10,7 +10,8 @@
     "format": "oxfmt 'src/**/*.{ts,tsx}'",
     "format:check": "oxfmt --check 'src/**/*.{ts,tsx}'",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "verify": "bun run lint && bun run test"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",

--- a/web/nextjs/src/components/counsel/CounselAppClient.tsx
+++ b/web/nextjs/src/components/counsel/CounselAppClient.tsx
@@ -3,12 +3,10 @@ import type { CounselAppProps } from "./CounselApp";
 /**
  * CounselApp is a component that renders a Counsel app inside an iframe.
  */
-export default function CounselAppClient({
-  signedAppUrl,
-  className,
-}: CounselAppProps) {
+export default function CounselAppClient({ signedAppUrl, className }: CounselAppProps) {
   return (
     <iframe
+      title="Counsel App"
       src={signedAppUrl}
       className={className}
       onError={(error) => {


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
- will help me sleep 

#### Relevant Screenshots (if any)
<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->
<img width="1624" height="985" alt="Screenshot 2026-04-03 at 4 55 26 PM" src="https://github.com/user-attachments/assets/152054c5-3cd6-402f-bbe6-7204e0869576" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI E2E pipeline that boots the full web+API stack with real secrets and runs browser automation, plus changes to Compose/env handling and Cloud Run workflows; failures could block merges or break deploys if secrets/env expectations are off.
> 
> **Overview**
> Adds a new `automation-testing/` Playwright suite (API + UI) with Bun-based lint/format/typecheck and CI-friendly configs to validate health, signup validation, and the embedded login/chat iframe flow.
> 
> Introduces a new GitHub Actions `E2E` workflow that fetches secrets from Doppler, starts the stack via `docker compose`, waits for readiness, runs Playwright, and uploads reports on failure (with stickydisk caching + cleanup).
> 
> Updates local/dev tooling and ops: `docker-compose.yml` now relies on explicit `environment:` var substitution instead of `env_file`, `start.sh` switches to `docker compose` + `doppler run`, root adds Husky + `lint-staged` + a repo-wide `verify`, and CD workflows bump action versions and set Cloud Run deploys to `wait: true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d972c7be17fd070cfdd2829c8ea408837f8a7e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->