### PR TITLE
chore: setup PR previews with cloudrun

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,292 @@
+# Deploys ephemeral preview environments to Cloud Run for every PR.
+# Triggers when Next.js / Node.js sources or this workflow file change.
+# Skips while the PR is draft; runs when marked ready for review.
+# Services scale to zero (min-instances=0) when idle — no billing when unused.
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, closed]
+    paths:
+      - "web/nextjs/**"
+      - "server/nodejs/**"
+      - ".github/workflows/pr-preview.yml"
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  GAR_LOCATION: ${{ vars.REGION }}
+  REGION: ${{ vars.REGION }}
+  PROJECT_ID: ${{ vars.PROJECT_ID }}
+  REPOSITORY: ${{ vars.REPOSITORY }}
+  NODEJS_SERVICE: embedded-demo-nodejs-server-pr-${{ github.event.number }}
+  NEXTJS_SERVICE: embedded-demo-nextjs-web-pr-${{ github.event.number }}
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed' && github.event.pull_request.draft != true
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect changed services
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            server:
+              - 'server/nodejs/**'
+            web:
+              - 'web/nextjs/**'
+            workflow:
+              - '.github/workflows/pr-preview.yml'
+
+      - name: Google Auth
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}
+          token_format: access_token
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGION }}-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}
+
+      # ── Node.js service ────────────────────────────────────────────────────
+
+      - name: Build and push Node.js image
+        if: steps.filter.outputs.server == 'true' || steps.filter.outputs.workflow == 'true'
+        working-directory: ./server/nodejs
+        run: |
+          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.NODEJS_SERVICE }}:${{ github.sha }}" ./
+          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.NODEJS_SERVICE }}:${{ github.sha }}"
+
+      # Note: bootstrap-nodejs below is a copy of this step — the only intentional
+      # difference is --max-instances=1 (bootstrap caps scale for first-time deploys).
+      - name: Deploy Node.js to Cloud Run
+        if: steps.filter.outputs.server == 'true' || steps.filter.outputs.workflow == 'true'
+        id: deploy-nodejs
+        uses: google-github-actions/deploy-cloudrun@v3
+        with:
+          wait: "true"
+          service: ${{ env.NODEJS_SERVICE }}
+          region: ${{ env.REGION }}
+          image: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.NODEJS_SERVICE }}:${{ github.sha }}
+          env_vars: |
+            NODE_ENV=production
+          flags: |
+            --port=4003
+            --allow-unauthenticated
+            --min-instances=0
+            --max-instances=5
+            --concurrency=1000
+            --timeout=300
+            --execution-environment=gen2
+            --set-secrets=ACCESS_CODE_CONFIGS=doppler-gsm-syncACCESS_CODE_CONFIGS:latest
+            --set-secrets=JWT_SECRET=doppler-gsm-syncJWT_SECRET:latest
+            --set-secrets=COUNSEL_WEBHOOK_SECRET=doppler-gsm-syncCOUNSEL_WEBHOOK_SECRET:latest
+            --set-secrets=COUNSEL_PRIVATE_KEY_PEM=doppler-gsm-syncCOUNSEL_PRIVATE_KEY_PEM:latest
+
+      # ── Check Node.js preview URL (needed for Next.js SERVER_HOST) ─────────
+      # Runs when web changed but server didn't — looks up the existing preview
+      # service URL, or triggers a Node.js deploy if the service doesn't exist yet.
+
+      - name: Check Node.js preview service
+        id: check-nodejs
+        if: steps.filter.outputs.web == 'true' && steps.filter.outputs.server != 'true'
+        run: |
+          URL=$(gcloud run services describe ${{ env.NODEJS_SERVICE }} \
+            --region=${{ env.REGION }} \
+            --format='value(status.url)' 2>/dev/null || echo "")
+          if [ -n "$URL" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "url=$URL" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "url=" >> $GITHUB_OUTPUT
+          fi
+
+      # Bootstrap: deploy Node.js when web changed but Node.js preview doesn't exist yet
+      # (e.g. first PR commit only touching web/nextjs/**)
+      - name: Bootstrap Node.js image (first deploy)
+        if: steps.filter.outputs.web == 'true' && steps.check-nodejs.outputs.exists == 'false'
+        working-directory: ./server/nodejs
+        run: |
+          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.NODEJS_SERVICE }}:${{ github.sha }}" ./
+          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.NODEJS_SERVICE }}:${{ github.sha }}"
+
+      - name: Bootstrap Node.js deploy (first deploy)
+        if: steps.filter.outputs.web == 'true' && steps.check-nodejs.outputs.exists == 'false'
+        id: bootstrap-nodejs
+        uses: google-github-actions/deploy-cloudrun@v3
+        with:
+          wait: "true"
+          service: ${{ env.NODEJS_SERVICE }}
+          region: ${{ env.REGION }}
+          image: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.NODEJS_SERVICE }}:${{ github.sha }}
+          env_vars: |
+            NODE_ENV=production
+          flags: |
+            --port=4003
+            --allow-unauthenticated
+            --min-instances=0
+            --max-instances=1
+            --concurrency=1000
+            --timeout=300
+            --execution-environment=gen2
+            --set-secrets=ACCESS_CODE_CONFIGS=doppler-gsm-syncACCESS_CODE_CONFIGS:latest
+            --set-secrets=JWT_SECRET=doppler-gsm-syncJWT_SECRET:latest
+            --set-secrets=COUNSEL_WEBHOOK_SECRET=doppler-gsm-syncCOUNSEL_WEBHOOK_SECRET:latest
+            --set-secrets=COUNSEL_PRIVATE_KEY_PEM=doppler-gsm-syncCOUNSEL_PRIVATE_KEY_PEM:latest
+
+      - name: Set Node.js preview URL
+        if: steps.filter.outputs.web == 'true' || steps.filter.outputs.server == 'true' || steps.filter.outputs.workflow == 'true'
+        run: |
+          # Prefer: fresh deploy > bootstrap deploy > existing service lookup
+          if [ -n "${{ steps.deploy-nodejs.outputs.url }}" ]; then
+            echo "NODEJS_PREVIEW_URL=${{ steps.deploy-nodejs.outputs.url }}" >> $GITHUB_ENV
+          elif [ -n "${{ steps.bootstrap-nodejs.outputs.url }}" ]; then
+            echo "NODEJS_PREVIEW_URL=${{ steps.bootstrap-nodejs.outputs.url }}" >> $GITHUB_ENV
+          else
+            echo "NODEJS_PREVIEW_URL=${{ steps.check-nodejs.outputs.url }}" >> $GITHUB_ENV
+          fi
+
+      # ── Next.js service ────────────────────────────────────────────────────
+
+      - name: Build and push Next.js image
+        if: steps.filter.outputs.web == 'true' || steps.filter.outputs.workflow == 'true'
+        working-directory: ./web/nextjs
+        run: |
+          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.NEXTJS_SERVICE }}:${{ github.sha }}" ./
+          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.NEXTJS_SERVICE }}:${{ github.sha }}"
+
+      - name: Deploy Next.js to Cloud Run
+        if: steps.filter.outputs.web == 'true' || steps.filter.outputs.workflow == 'true'
+        id: deploy-nextjs
+        uses: google-github-actions/deploy-cloudrun@v3
+        with:
+          wait: "true"
+          service: ${{ env.NEXTJS_SERVICE }}
+          region: ${{ env.REGION }}
+          image: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.NEXTJS_SERVICE }}:${{ github.sha }}
+          env_vars: |
+            NODE_ENV=production
+            SERVER_HOST=${{ env.NODEJS_PREVIEW_URL }}
+          flags: |
+            --port=3001
+            --allow-unauthenticated
+            --min-instances=0
+            --max-instances=1
+            --concurrency=1000
+            --timeout=300
+            --execution-environment=gen2
+            --cpu=2
+            --memory=2Gi
+            --set-secrets=IRON_SESSION_PASSWORD=doppler-gsm-syncIRON_SESSION_PASSWORD:latest
+
+      # ── PR comment ─────────────────────────────────────────────────────────
+
+      - name: Resolve final preview URLs
+        id: resolve-urls
+        run: |
+          # Next.js URL
+          if [ -n "${{ steps.deploy-nextjs.outputs.url }}" ]; then
+            NEXTJS_URL="${{ steps.deploy-nextjs.outputs.url }}"
+          else
+            NEXTJS_URL=$(gcloud run services describe ${{ env.NEXTJS_SERVICE }} \
+              --region=${{ env.REGION }} \
+              --format='value(status.url)' 2>/dev/null || echo "not deployed")
+          fi
+
+          # Node.js URL
+          if [ -n "${{ steps.deploy-nodejs.outputs.url }}" ]; then
+            NODEJS_URL="${{ steps.deploy-nodejs.outputs.url }}"
+          elif [ -n "${{ steps.bootstrap-nodejs.outputs.url }}" ]; then
+            NODEJS_URL="${{ steps.bootstrap-nodejs.outputs.url }}"
+          else
+            NODEJS_URL=$(gcloud run services describe ${{ env.NODEJS_SERVICE }} \
+              --region=${{ env.REGION }} \
+              --format='value(status.url)' 2>/dev/null || echo "not deployed")
+          fi
+
+          echo "nextjs_url=$NEXTJS_URL" >> $GITHUB_OUTPUT
+          echo "nodejs_url=$NODEJS_URL" >> $GITHUB_OUTPUT
+
+      - name: Update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- pr-preview -->';
+            const nextjsUrl = '${{ steps.resolve-urls.outputs.nextjs_url }}';
+            const nodejsUrl = '${{ steps.resolve-urls.outputs.nodejs_url }}';
+            const sha = '${{ github.sha }}'.slice(0, 7);
+            const now = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+
+            const body = [
+              marker,
+              '## Preview Deployments',
+              '| Service | URL |',
+              '|---------|-----|',
+              `| Demo App | ${nextjsUrl} |`,
+              `| Demo API | ${nodejsUrl} |`,
+              '',
+              `Updated: ${now} · Commit: \`${sha}\``,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find((c) => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Google Auth
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Delete preview services
+        run: |
+          gcloud run services delete ${{ env.NODEJS_SERVICE }} --region=${{ env.REGION }} --quiet || true
+          gcloud run services delete ${{ env.NEXTJS_SERVICE }} --region=${{ env.REGION }} --quiet || true


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
- Deploy services on each PR we can test!
- iFrame is blocking the URL right now, will need to figure that one out

#### Relevant Screenshots (if any)
<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new CI/CD automation that deploys publicly accessible Cloud Run services and wires in multiple production secrets; misconfiguration could expose endpoints or incur unexpected resource usage.
> 
> **Overview**
> Introduces a new GitHub Actions workflow (`.github/workflows/pr-preview.yml`) that **builds and deploys ephemeral per-PR Cloud Run services** for both the Node.js API and Next.js app, using PR-number-based service names and concurrency controls.
> 
> The workflow conditionally builds/deploys only the changed service(s), bootstraps the API if the web changes first, passes the API preview URL to the web via `SERVER_HOST`, and posts/updates a PR comment with the resulting preview URLs.
> 
> On PR close, it **deletes the two Cloud Run preview services** to clean up resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2985be3196abaa858dcac3d010c0164c82c2dfd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->