### PR TITLE
easy: setup initial messages and agent context handoff

### DIFF
--- a/automation-testing/README.md
+++ b/automation-testing/README.md
@@ -38,7 +38,7 @@ bun run test:e2e:api   # or test:e2e:ui / test:e2e
 | `CI`              | Set by CI (workers, retries, headless) | —                       |
 | `HEADLESS`        | `true` → headless browser (local UI)   | —                       |
 | `E2E_ACCESS_CODE` | Required for embedded-flow login test  | —                       |
-| `E2E_ACCESS_CODE_INTEGRATED` | Access code with `navMode: integrated` for [integrated-handoff](ui/integrated-handoff.spec.ts) (hits real Counsel API; defaults to `AICHAT` if unset) | — |
+| `E2E_ACCESS_CODE_INTEGRATED` | Optional; access code with `navMode: integrated` for [integrated-handoff](ui/integrated-handoff.spec.ts). If unset, falls back to `E2E_ACCESS_CODE` (CI) then `AICHAT` | — |
 
 ## CI
 

--- a/automation-testing/README.md
+++ b/automation-testing/README.md
@@ -17,7 +17,7 @@ bun run playwright:install
 bun run test:e2e
 ```
 
-`test:e2e` uses **`doppler run`**, so secrets like **`E2E_ACCESS_CODE`** reach Playwright. Doppler finds **`doppler.yaml`** in a parent directory.
+`test:e2e` uses **`doppler run`**, so secrets like **`E2E_ACCESS_CODE`** and **`E2E_ACCESS_CODE_INTEGRATED`** reach Playwright. Doppler finds **`doppler.yaml`** in a parent directory.
 
 ## Other local runs
 
@@ -38,10 +38,11 @@ bun run test:e2e:api   # or test:e2e:ui / test:e2e
 | `CI`              | Set by CI (workers, retries, headless) | —                       |
 | `HEADLESS`        | `true` → headless browser (local UI)   | —                       |
 | `E2E_ACCESS_CODE` | Required for embedded-flow login test  | —                       |
+| `E2E_ACCESS_CODE_INTEGRATED` | Access code with `navMode: integrated` for [integrated-handoff](ui/integrated-handoff.spec.ts) (hits real Counsel API; defaults to `AICHAT` if unset) | — |
 
 ## CI
 
-Workflow: [.github/workflows/ci-e2e.yml](../.github/workflows/ci-e2e.yml). It fetches secrets with **`dopplerhq/secrets-fetch-action`** (**`inject-env-vars: true`** puts them on the job environment). **`docker compose up`** starts the stack; Compose resolves **`${VAR}`** in [docker-compose.yml](../docker-compose.yml) from that environment first (so web/server containers receive Doppler values). Playwright (**`test:e2e:ci`**) only runs tests against those URLs and sees the same job env (e.g. **`E2E_ACCESS_CODE`**). Blacksmith **stickydisk** caches `automation-testing/node_modules` and `~/.cache/ms-playwright`; the cleanup job’s **delete-key** values must match the mount keys in the workflow.
+Workflow: [.github/workflows/ci-e2e.yml](../.github/workflows/ci-e2e.yml). It fetches secrets with **`dopplerhq/secrets-fetch-action`** (**`inject-env-vars: true`** puts them on the job environment). **`docker compose up`** starts the stack; Compose resolves **`${VAR}`** in [docker-compose.yml](../docker-compose.yml) from that environment first (so web/server containers receive Doppler values). Playwright (**`test:e2e:ci`**) only runs tests against those URLs and sees the same job env (e.g. **`E2E_ACCESS_CODE`**, **`E2E_ACCESS_CODE_INTEGRATED`**). Blacksmith **stickydisk** caches `automation-testing/node_modules` and `~/.cache/ms-playwright`; the cleanup job’s **delete-key** values must match the mount keys in the workflow.
 
 **Repo settings:** secret **`DOPPLER_CI_TOKEN`**; variables **`DOPPLER_PROJECT`** and **`DOPPLER_CONFIG`** if your token needs them.
 

--- a/automation-testing/ui/integrated-handoff.spec.ts
+++ b/automation-testing/ui/integrated-handoff.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+// Integrated navMode JWT access code (redirects to /integrated/chat). Override in CI/local via Doppler or env.
+const accessCode = process.env["E2E_ACCESS_CODE_INTEGRATED"] ?? "AICHAT";
+
+test.describe("integrated chat - connect to care handoff", () => {
+  test("real Counsel API: signedAppUrl succeeds and Counsel iframe loads", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    await page.getByLabel("Access Code").fill(accessCode!);
+    await page.getByRole("button", { name: "Login" }).click();
+    await expect(page).toHaveURL(/\/(dashboard|integrated)/, {
+      timeout: 15_000,
+    });
+
+    if (!page.url().includes("/integrated/chat")) {
+      await page.goto("/integrated/chat");
+    }
+    await page.waitForLoadState("domcontentloaded");
+
+    const chatInput = page.getByPlaceholder("Type a message…");
+    await expect(chatInput).toBeVisible({ timeout: 10_000 });
+
+    const triggerText = "I need to see a doctor about my symptoms";
+    await chatInput.click();
+    await chatInput.pressSequentially(triggerText, { delay: 30 });
+    await page.getByRole("button", { name: "Send" }).click();
+
+    await expect(
+      page.getByRole("button", { name: "Connect to Counsel" })
+    ).toBeVisible();
+
+    const signedUrlResponse = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/signedAppUrl") &&
+        resp.request().method() === "POST" &&
+        resp.request().resourceType() === "fetch"
+    );
+
+    await page.getByRole("button", { name: "Connect to Counsel" }).click();
+
+    const response = await signedUrlResponse;
+    expect(response.ok(), `signedAppUrl failed: ${response.status()}`).toBe(
+      true
+    );
+
+    await expect(
+      page.getByRole("button", { name: /Counsel chat/ })
+    ).toBeVisible({ timeout: 15_000 });
+
+    const iframe = page.getByTitle("Counsel App");
+    await expect(iframe).toBeVisible({ timeout: 30_000 });
+    const src = await iframe.getAttribute("src");
+    expect(src).toBeTruthy();
+    expect(src).toMatch(/^https?:\/\//);
+  });
+});

--- a/automation-testing/ui/integrated-handoff.spec.ts
+++ b/automation-testing/ui/integrated-handoff.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "@playwright/test";
 
-// Integrated navMode JWT access code (redirects to /integrated/chat). Override in CI/local via Doppler or env.
-const accessCode = process.env["E2E_ACCESS_CODE_INTEGRATED"] ?? "AICHAT";
+// Prefer a code with navMode: integrated; otherwise use the same JWT code as embedded-flow (CI sets E2E_ACCESS_CODE).
+const accessCode =
+  process.env["E2E_ACCESS_CODE_INTEGRATED"] ?? process.env["E2E_ACCESS_CODE"] ?? "AICHAT";
 
 test.describe("integrated chat - connect to care handoff", () => {
   test("real Counsel API: signedAppUrl succeeds and Counsel iframe loads", async ({

--- a/automation-testing/ui/integrated-handoff.spec.ts
+++ b/automation-testing/ui/integrated-handoff.spec.ts
@@ -2,7 +2,9 @@ import { expect, test } from "@playwright/test";
 
 // Prefer a code with navMode: integrated; otherwise use the same JWT code as embedded-flow (CI sets E2E_ACCESS_CODE).
 const accessCode =
-  process.env["E2E_ACCESS_CODE_INTEGRATED"] ?? process.env["E2E_ACCESS_CODE"] ?? "AICHAT";
+  process.env["E2E_ACCESS_CODE_INTEGRATED"] ??
+  process.env["E2E_ACCESS_CODE"] ??
+  "AICHAT";
 
 test.describe("integrated chat - connect to care handoff", () => {
   test("real Counsel API: signedAppUrl succeeds and Counsel iframe loads", async ({

--- a/web/nextjs/src/app/api/counsel/signedAppUrl/route.ts
+++ b/web/nextjs/src/app/api/counsel/signedAppUrl/route.ts
@@ -1,0 +1,51 @@
+import { getSession } from "@/lib/session";
+import { serverEnv } from "@/envConfig";
+import { getValidCounselJwt } from "@/lib/server";
+import { fetchWithRetry } from "@/lib/http";
+
+/**
+ * Proxies POST /v1/user/:id/signedAppUrl for the integrated chat client.
+ */
+export async function POST(req: Request) {
+  const session = await getSession();
+  if (!session.token || !session.counselUserId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const sessionData = await req.json();
+  const counselJwt = await getValidCounselJwt(session);
+
+  if (session.authType === "jwt" && counselJwt) {
+    const resp = await fetchWithRetry(
+      `${serverEnv.COUNSEL_API_URL}/v1/user/${session.counselUserId}/signedAppUrl`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${counselJwt}`,
+          "Idempotency-Key": crypto.randomUUID(),
+        },
+        body: JSON.stringify(sessionData),
+      },
+    );
+    const body = await resp.text();
+    return new Response(body, {
+      status: resp.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const resp = await fetchWithRetry(`${serverEnv.SERVER_HOST}/user/signedAppUrl`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`,
+    },
+    body: JSON.stringify(sessionData),
+  });
+  const body = await resp.text();
+  return new Response(body, {
+    status: resp.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/web/nextjs/src/app/api/counsel/threads/route.ts
+++ b/web/nextjs/src/app/api/counsel/threads/route.ts
@@ -1,0 +1,50 @@
+import { getSession } from "@/lib/session";
+import { serverEnv } from "@/envConfig";
+import { getValidCounselJwt } from "@/lib/server";
+import { fetchWithRetry } from "@/lib/http";
+
+/**
+ * Proxies GET /v1/user/:id/threads for the integrated chat client.
+ * Uses the Counsel JWT when authType is jwt; otherwise forwards to the demo
+ * server with the session token (API key flow).
+ */
+export async function GET() {
+  const session = await getSession();
+  if (!session.token || !session.counselUserId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const counselJwt = await getValidCounselJwt(session);
+
+  if (session.authType === "jwt" && counselJwt) {
+    const resp = await fetchWithRetry(
+      `${serverEnv.COUNSEL_API_URL}/v1/user/${session.counselUserId}/threads`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${counselJwt}`,
+          "Idempotency-Key": crypto.randomUUID(),
+        },
+      },
+    );
+    const body = await resp.text();
+    return new Response(body, {
+      status: resp.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const resp = await fetchWithRetry(`${serverEnv.SERVER_HOST}/user/threads`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`,
+    },
+  });
+  const body = await resp.text();
+  return new Response(body, {
+    status: resp.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/web/nextjs/src/app/integrated/chat/page.tsx
+++ b/web/nextjs/src/app/integrated/chat/page.tsx
@@ -5,8 +5,8 @@ import { getValidCounselJwt } from "@/lib/server";
 
 /**
  * Integrated chat page — thin shell that reads session credentials
- * and passes them to the client. All API calls (threads, signed URLs)
- * happen directly from the browser to the Counsel API using JWT auth.
+ * and passes them to the client. JWT auth calls Counsel from the browser;
+ * API key auth uses `/api/counsel/*` proxies with the session cookie.
  */
 export default async function IntegratedChat() {
   const session = await getSession();
@@ -15,7 +15,7 @@ export default async function IntegratedChat() {
   return (
     <IntegratedChatPage
       counselApiConfig={{
-        counselApiUrl: serverEnv.COUNSEL_API_URL,
+        counselDirectApiBase: `${serverEnv.COUNSEL_API_URL}/v1/user/${session.counselUserId}`,
         counselJwt: counselJwt ?? "",
         counselUserId: session.counselUserId,
       }}

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -177,7 +177,21 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
     async (hostThreadId: string) => {
       if (isLoading) return;
       try {
-        const url = await getSignedUrl({ action: "create_thread" });
+        const thread = hostThreads.find((t) => t.id === hostThreadId);
+        const messages = thread?.messages ?? [];
+
+        const initial_messages = messages.map((m) => ({
+          body: m.text,
+          role: m.role === "user" ? ("patient" as const) : ("model" as const),
+        }));
+
+        const reason_for_handoff = "Agent detected a need for medical assistance";
+
+        const url = await getSignedUrl({
+          action: "create_thread",
+          initial_messages,
+          agent_context: { reason_for_handoff },
+        });
 
         setHostThreads((prev) =>
           prev.map((t) => (t.id === hostThreadId ? { ...t, showCounselCard: false } : t)),
@@ -200,7 +214,7 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
         console.error("Failed to connect to Counsel:", error);
       }
     },
-    [isLoading, getSignedUrl, addThread, invalidateThreads],
+    [isLoading, getSignedUrl, addThread, invalidateThreads, hostThreads],
   );
 
   // ---- Render -------------------------------------------------------------

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -61,7 +61,7 @@ function createNewHostThread(): HostThread {
 type ActiveThread = { type: "host"; id: string } | { type: "counsel"; id: string };
 
 type IntegratedChatPageProps = {
-  /** Credentials for calling the Counsel API directly from the browser. */
+  /** Counsel API routing: JWT calls Counsel directly; API key sessions use `/api/counsel/*` proxies. */
   counselApiConfig: CounselApiConfig;
 };
 
@@ -74,8 +74,8 @@ type IntegratedChatPageProps = {
  * the host app manages the thread sidebar and renders either its own chat
  * UI (host threads) or the Counsel iframe (Counsel threads).
  *
- * All API calls (threads, signed URLs) go directly from the browser to
- * the Counsel API using JWT auth — no demo server or Next.js middleman.
+ * JWT sessions call the Counsel API from the browser; API key sessions use
+ * Next.js route handlers that proxy to the demo server (same as dashboard chat).
  */
 export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatPageProps) {
   const defaultThread = createDefaultHostThread();

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -185,7 +185,9 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
           role: m.role === "user" ? ("patient" as const) : ("model" as const),
         }));
 
-        const reason_for_handoff = "Agent detected a need for medical assistance";
+        const lastUserMessage = [...messages].reverse().find((m) => m.role === "user");
+        const reason_for_handoff =
+          lastUserMessage?.text ?? "Agent detected a need for medical assistance";
 
         const url = await getSignedUrl({
           action: "create_thread",

--- a/web/nextjs/src/hooks/useCounselApi.ts
+++ b/web/nextjs/src/hooks/useCounselApi.ts
@@ -8,12 +8,15 @@ import { counselQueryKeys } from "./counselQueryKeys";
 // ---------------------------------------------------------------------------
 
 export type CounselApiConfig = {
-  /** Counsel API URL (e.g. http://localhost:4002) */
-  counselApiUrl: string;
-  /** Counsel JWT for Bearer auth against the Counsel API */
-  counselJwt: string;
   /** Counsel user ID */
   counselUserId: string;
+  /**
+   * When set, calls `${counselDirectApiBase}/…` with Bearer auth (JWT flow).
+   * When empty, calls same-origin `/api/counsel/…` with session cookies (API key flow via demo server proxy).
+   */
+  counselJwt: string;
+  /** `${COUNSEL_API_URL}/v1/user/${counselUserId}` — used only when counselJwt is set */
+  counselDirectApiBase: string;
 };
 
 export type InitialMessage = { body: string; role: "patient" | "model" };
@@ -31,13 +34,21 @@ type SignedUrlAction =
 // ---------------------------------------------------------------------------
 
 async function fetchThreadsFromServer(config: CounselApiConfig): Promise<ThreadItem[]> {
-  const resp = await fetch(`${config.counselApiUrl}/v1/user/${config.counselUserId}/threads`, {
+  const direct = config.counselJwt.length > 0;
+  const url = direct
+    ? `${config.counselDirectApiBase}/threads`
+    : "/api/counsel/threads";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Idempotency-Key": crypto.randomUUID(),
+  };
+  if (direct) {
+    headers.Authorization = `Bearer ${config.counselJwt}`;
+  }
+  const resp = await fetch(url, {
     method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${config.counselJwt}`,
-      "Idempotency-Key": crypto.randomUUID(),
-    },
+    headers,
+    credentials: direct ? "omit" : "include",
   });
   if (!resp.ok) {
     throw new Error(`Failed to fetch threads: ${resp.status}`);
@@ -67,13 +78,21 @@ async function fetchSignedUrlFromServer(
     }
   }
 
-  const resp = await fetch(`${config.counselApiUrl}/v1/user/${config.counselUserId}/signedAppUrl`, {
+  const direct = config.counselJwt.length > 0;
+  const signedUrlEndpoint = direct
+    ? `${config.counselDirectApiBase}/signedAppUrl`
+    : "/api/counsel/signedAppUrl";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Idempotency-Key": crypto.randomUUID(),
+  };
+  if (direct) {
+    headers.Authorization = `Bearer ${config.counselJwt}`;
+  }
+  const resp = await fetch(signedUrlEndpoint, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${config.counselJwt}`,
-      "Idempotency-Key": crypto.randomUUID(),
-    },
+    headers,
+    credentials: direct ? "omit" : "include",
     body: JSON.stringify(sessionData),
   });
   if (!resp.ok) {
@@ -102,7 +121,7 @@ export function useCounselThreads(config: CounselApiConfig) {
   } = useQuery({
     queryKey,
     queryFn: () => fetchThreadsFromServer(config),
-    enabled: !!config.counselJwt && !!config.counselUserId,
+    enabled: !!config.counselUserId,
   });
 
   const addThread = useCallback(

--- a/web/nextjs/src/hooks/useCounselApi.ts
+++ b/web/nextjs/src/hooks/useCounselApi.ts
@@ -16,7 +16,15 @@ export type CounselApiConfig = {
   counselUserId: string;
 };
 
-type SignedUrlAction = { action: "open_thread"; thread_id: string } | { action: "create_thread" };
+export type InitialMessage = { body: string; role: "patient" | "model" };
+
+type SignedUrlAction =
+  | { action: "open_thread"; thread_id: string }
+  | {
+      action: "create_thread";
+      initial_messages?: InitialMessage[];
+      agent_context?: Record<string, unknown>;
+    };
 
 // ---------------------------------------------------------------------------
 // Raw fetch helpers
@@ -46,7 +54,14 @@ async function fetchSignedUrlFromServer(
     view: { navigation: "integrated" },
   };
   if (action) {
-    sessionData.action = action;
+    if (action.action === "create_thread") {
+      const { initial_messages, agent_context, ...actionBase } = action;
+      sessionData.action = actionBase;
+      if (initial_messages) Object.assign(actionBase, { initial_messages });
+      if (agent_context) Object.assign(actionBase, { agent_context });
+    } else {
+      sessionData.action = action;
+    }
   }
 
   const resp = await fetch(`${config.counselApiUrl}/v1/user/${config.counselUserId}/signedAppUrl`, {

--- a/web/nextjs/src/hooks/useCounselApi.ts
+++ b/web/nextjs/src/hooks/useCounselApi.ts
@@ -54,14 +54,7 @@ async function fetchSignedUrlFromServer(
     view: { navigation: "integrated" },
   };
   if (action) {
-    if (action.action === "create_thread") {
-      const { initial_messages, agent_context, ...actionBase } = action;
-      sessionData.action = actionBase;
-      if (initial_messages) Object.assign(actionBase, { initial_messages });
-      if (agent_context) Object.assign(actionBase, { agent_context });
-    } else {
-      sessionData.action = action;
-    }
+    sessionData.action = action;
   }
 
   const resp = await fetch(`${config.counselApiUrl}/v1/user/${config.counselUserId}/signedAppUrl`, {

--- a/web/nextjs/src/hooks/useCounselApi.ts
+++ b/web/nextjs/src/hooks/useCounselApi.ts
@@ -54,7 +54,17 @@ async function fetchSignedUrlFromServer(
     view: { navigation: "integrated" },
   };
   if (action) {
-    sessionData.action = action;
+    // Counsel signedAppUrl expects a single `action` object. For create_thread,
+    // initial_messages and agent_context must live on that object (not on sessionData).
+    if (action.action === "create_thread") {
+      sessionData.action = {
+        action: "create_thread",
+        initial_messages: action.initial_messages,
+        agent_context: action.agent_context,
+      };
+    } else {
+      sessionData.action = action;
+    }
   }
 
   const resp = await fetch(`${config.counselApiUrl}/v1/user/${config.counselUserId}/signedAppUrl`, {


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
- send messages & agent context
- write a test :D

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Next.js API proxy routes and changes integrated chat networking behavior (direct vs proxied requests) plus modifies the payload sent to Counsel when creating threads, which could impact handoff flows and auth/cookie handling.
> 
> **Overview**
> Improves integrated-chat “connect to Counsel” handoff by sending `initial_messages` and an `agent_context.reason_for_handoff` when requesting a `signedAppUrl` for `create_thread`.
> 
> Adds same-origin `/api/counsel/threads` and `/api/counsel/signedAppUrl` route handlers and updates `useCounselApi`/`IntegratedChatPage` to route requests **directly to Counsel when a JWT is present** or **through these proxies for API-key sessions** (using session cookies). Also adds a Playwright E2E spec for the integrated handoff flow and documents the new `E2E_ACCESS_CODE_INTEGRATED` secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30a4d1cbda411218d73bf0ffb2cbd7c86b3b1663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->