### PR TITLE
easy: demo feedback pt. 1

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       - name: Lint, format, typecheck (automation-testing)
         working-directory: ./automation-testing
         run: |
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       - name: Mount automation-testing node_modules (stickydisk)
         uses: useblacksmith/stickydisk@v1

--- a/.github/workflows/ci-nextjs-web.yml
+++ b/.github/workflows/ci-nextjs-web.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/ci-nodejs-server.yml
+++ b/.github/workflows/ci-nodejs-server.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/server/nodejs/.oxlint/logger-err-plugin.cjs
+++ b/server/nodejs/.oxlint/logger-err-plugin.cjs
@@ -1,0 +1,65 @@
+"use strict";
+
+/**
+ * Flags logger.error(...) / logger.warn(...) calls whose first argument is an object
+ * containing a property with key "error" and value that is a variable (Identifier).
+ * Error instances serialize as {} when logged under a generic key; use key "err" so Pino serializes them.
+ */
+const LOG_METHODS = ["error", "warn"];
+
+function isLoggerCallee(callee) {
+  if (callee.type !== "MemberExpression") return false;
+  const prop = callee.property;
+  if (prop.type !== "Identifier") return false;
+  if (!LOG_METHODS.includes(prop.name)) return false;
+  const obj = callee.object;
+  return obj.type === "Identifier";
+}
+
+function hasErrorPropertyWithIdentifier(objNode) {
+  if (objNode.type !== "ObjectExpression") return false;
+  for (const prop of objNode.properties) {
+    if (prop.type !== "Property") continue;
+    const key = prop.key?.type === "Identifier" ? prop.key.name : null;
+    if (key !== "error") continue;
+    const value = prop.value;
+    if (value.type === "Identifier") return true;
+    if (prop.shorthand) return true;
+  }
+  return false;
+}
+
+const rule = {
+  meta: {
+    name: "logger-err-key",
+    docs: {
+      description:
+        "Use key 'err' when logging Error instances so Pino serializes message and stack; 'error' serializes as {}.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        if (!isLoggerCallee(callee)) return;
+        const firstArg = node.arguments[0];
+        if (!firstArg) return;
+        if (!hasErrorPropertyWithIdentifier(firstArg)) return;
+        context.report({
+          node: firstArg,
+          message:
+            "Use key 'err' for Error instances when logging so Pino serializes them; 'error' serializes as {}.",
+        });
+      },
+    };
+  },
+};
+
+const plugin = {
+  meta: { name: "logger-err" },
+  rules: {
+    "use-err-for-error-instances": rule,
+  },
+};
+
+module.exports = plugin;

--- a/server/nodejs/.oxlintrc.json
+++ b/server/nodejs/.oxlintrc.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
   "plugins": ["typescript", "import"],
+  "jsPlugins": ["./.oxlint/logger-err-plugin.cjs"],
   "rules": {
-    "no-unused-vars": "error"
+    "no-unused-vars": "error",
+    "logger-err/use-err-for-error-instances": "error"
   }
 }

--- a/server/nodejs/src/app.ts
+++ b/server/nodejs/src/app.ts
@@ -87,7 +87,7 @@ const app = new Elysia()
     set.status = httpStatus;
 
     if (httpStatus >= 500) {
-      httpLogger.error({ method, path, status: httpStatus, error: err }, "Server error");
+      httpLogger.error({ method, path, status: httpStatus, err }, "Server error");
     } else {
       // 4xx from HttpError (e.g. 404 catch-all) — not a server fault
       httpLogger.warn({ method, path, status: httpStatus, error: err.message }, "Client error");

--- a/server/nodejs/src/index.ts
+++ b/server/nodejs/src/index.ts
@@ -1,6 +1,6 @@
 import app from "@/app";
-import { env, loadEnvConfig } from "@/envConfig";
 import { getDb } from "@/db/db";
+import { env, loadEnvConfig } from "@/envConfig";
 import { serverLogger } from "@/lib/logger";
 
 loadEnvConfig();
@@ -12,7 +12,7 @@ app.listen(env.PORT, () => {
       serverLogger.info("Database initialized");
     })
     .catch((error) => {
-      serverLogger.error({ error }, "Critical error initializing the database");
+      serverLogger.error({ err: error }, "Critical error initializing the database");
       process.exit(1);
     });
 

--- a/server/nodejs/src/lib/http.ts
+++ b/server/nodejs/src/lib/http.ts
@@ -54,7 +54,7 @@ export async function fetchWithRetry(
     try {
       return await fetch(url, options);
     } catch (error) {
-      httpLogger.warn({ url, delay, error }, "Request failed, retrying");
+      httpLogger.warn({ url, delay, err: error }, "Request failed, retrying");
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }

--- a/server/nodejs/src/lib/webhook-verification.ts
+++ b/server/nodejs/src/lib/webhook-verification.ts
@@ -12,7 +12,7 @@ export function verifyWebhook(
     wh.verify(JSON.stringify(body), headers as Record<string, string>);
     return true;
   } catch (error) {
-    webhookLogger.error({ error }, "Webhook verification failed");
+    webhookLogger.error({ err: error }, "Webhook verification failed");
     // Return 400 if the webhook verification fails
     throw new HttpError("Invalid webhook signature or timestamp", 400);
   }

--- a/web/nextjs/.oxlint/logger-err-plugin.cjs
+++ b/web/nextjs/.oxlint/logger-err-plugin.cjs
@@ -1,0 +1,65 @@
+"use strict";
+
+/**
+ * Flags logger.error(...) / logger.warn(...) calls whose first argument is an object
+ * containing a property with key "error" and value that is a variable (Identifier).
+ * Error instances serialize as {} when logged under a generic key; use key "err" so Pino serializes them.
+ */
+const LOG_METHODS = ["error", "warn"];
+
+function isLoggerCallee(callee) {
+  if (callee.type !== "MemberExpression") return false;
+  const prop = callee.property;
+  if (prop.type !== "Identifier") return false;
+  if (!LOG_METHODS.includes(prop.name)) return false;
+  const obj = callee.object;
+  return obj.type === "Identifier";
+}
+
+function hasErrorPropertyWithIdentifier(objNode) {
+  if (objNode.type !== "ObjectExpression") return false;
+  for (const prop of objNode.properties) {
+    if (prop.type !== "Property") continue;
+    const key = prop.key?.type === "Identifier" ? prop.key.name : null;
+    if (key !== "error") continue;
+    const value = prop.value;
+    if (value.type === "Identifier") return true;
+    if (prop.shorthand) return true;
+  }
+  return false;
+}
+
+const rule = {
+  meta: {
+    name: "logger-err-key",
+    docs: {
+      description:
+        "Use key 'err' when logging Error instances so Pino serializes message and stack; 'error' serializes as {}.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        if (!isLoggerCallee(callee)) return;
+        const firstArg = node.arguments[0];
+        if (!firstArg) return;
+        if (!hasErrorPropertyWithIdentifier(firstArg)) return;
+        context.report({
+          node: firstArg,
+          message:
+            "Use key 'err' for Error instances when logging so Pino serializes them; 'error' serializes as {}.",
+        });
+      },
+    };
+  },
+};
+
+const plugin = {
+  meta: { name: "logger-err" },
+  rules: {
+    "use-err-for-error-instances": rule,
+  },
+};
+
+module.exports = plugin;

--- a/web/nextjs/.oxlintrc.json
+++ b/web/nextjs/.oxlintrc.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
   "plugins": ["typescript", "import", "jsx-a11y", "react", "react-hooks", "nextjs"],
+  "jsPlugins": ["./.oxlint/logger-err-plugin.cjs"],
   "rules": {
     "no-unused-vars": "error",
-    "no-unused-private-class-members": "error"
+    "no-unused-private-class-members": "error",
+    "logger-err/use-err-for-error-instances": "error"
   }
 }

--- a/web/nextjs/src/actions/signOut.ts
+++ b/web/nextjs/src/actions/signOut.ts
@@ -13,7 +13,7 @@ export async function signOut() {
   if (token) {
     // Don't block the sign out process if there's a server error
     signOutCounselUser(token).catch((error) => {
-      authLogger.error({ error }, "Failed to sign out user from demo server");
+      authLogger.error({ err: error }, "Failed to sign out user from demo server");
     });
   }
   // Destroy the session

--- a/web/nextjs/src/app/globals.css
+++ b/web/nextjs/src/app/globals.css
@@ -1,6 +1,9 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+/* Light-only Tailwind variant, for dark mode to be applied the style must have the .dark class set instead of reading prefers-color-scheme */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/web/nextjs/src/app/integrated/layout.tsx
+++ b/web/nextjs/src/app/integrated/layout.tsx
@@ -8,7 +8,7 @@ export default function IntegratedLayout({
 }) {
   return (
     <QueryProvider>
-      <div className="flex flex-col h-dvh w-screen overflow-hidden">
+      <div className="fixed inset-0 flex flex-col overflow-hidden">
         <main className="flex-1 h-full min-h-0">{children}</main>
       </div>
     </QueryProvider>

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -1,19 +1,19 @@
 "use client";
 
 import { signOut } from "@/actions/signOut";
-import { clientLogger } from "@/lib/clientLogger";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
+import { counselQueryKeys } from "@/hooks/counselQueryKeys";
 import {
+  pollUntilNewCounselThread,
   useCounselSignedUrl,
   useCounselThreads,
   type CounselApiConfig,
 } from "@/hooks/useCounselApi";
-import { useCallback, useState } from "react";
+import { clientLogger } from "@/lib/clientLogger";
+import { handlePromiseRejection } from "@/lib/handlePromiseRejection";
+import { useQueryClient } from "@tanstack/react-query";
 import { PanelLeftOpen } from "lucide-react";
-import {
-  Sheet,
-  SheetContent,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ChatList from "./integrated/ChatList";
 import ChatThread from "./integrated/ChatThread";
 import CounselChatThread from "./integrated/CounselChatThread";
@@ -92,6 +92,8 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
     type: "host",
     id: defaultThread.id,
   });
+  const activeThreadRef = useRef<ActiveThread>(activeThread);
+  activeThreadRef.current = activeThread;
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   // The signed URL currently loaded in the Counsel iframe. Kept stable so the
   // iframe is not reloaded unnecessarily — switching threads uses switch_thread.
@@ -99,6 +101,7 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
   // When set, triggers a counsel:switchThread postMessage to the live iframe.
   const [activeCounselThreadId, setActiveCounselThreadId] = useState<string | null>(null);
 
+  const queryClient = useQueryClient();
   const {
     threads: counselThreads,
     isLoading: isThreadsLoading,
@@ -106,6 +109,13 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
     invalidateThreads,
   } = useCounselThreads(counselApiConfig);
   const { getSignedUrl, isPending: isLoading } = useCounselSignedUrl(counselApiConfig);
+
+  const threadPollAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => {
+    return () => {
+      threadPollAbortRef.current?.abort();
+    };
+  }, []);
 
   // ---- Handlers -----------------------------------------------------------
 
@@ -136,7 +146,7 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
           : await getSignedUrl({ action: "open_thread", thread_id: threadId });
         setCounselSessionUrl(url);
       } catch (error) {
-        clientLogger.error({ error }, "Failed to load Counsel thread");
+        clientLogger.error({ err: error }, "Failed to load Counsel thread");
       }
     },
     [isLoading, getSignedUrl, counselSessionUrl],
@@ -207,6 +217,8 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
           agent_context: { reason_for_handoff },
         });
 
+        const baselineThreadIds = new Set(counselThreads.map((t) => t.id));
+
         setHostThreads((prev) =>
           prev.map((t) => (t.id === hostThreadId ? { ...t, showCounselCard: false } : t)),
         );
@@ -221,12 +233,60 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
         setActiveThread({ type: "counsel", id: placeholderId });
         setCounselSessionUrl(url);
         setActiveCounselThreadId(null);
-        invalidateThreads();
+
+        threadPollAbortRef.current?.abort();
+        threadPollAbortRef.current = new AbortController();
+        const signal = threadPollAbortRef.current.signal;
+
+        // TODO(cleanup): Drop this block when `pollUntilNewCounselThread` is removed (server create or embed message).
+        handlePromiseRejection(
+          async () => {
+            const result = await pollUntilNewCounselThread(
+              counselApiConfig,
+              baselineThreadIds,
+              signal,
+            );
+            if (signal.aborted) return;
+            if (!result) {
+              clientLogger.warn(
+                "Timed out waiting for new Counsel thread; sidebar may be stale until refresh",
+              );
+              await invalidateThreads();
+              return;
+            }
+            queryClient.setQueryData(
+              counselQueryKeys.threads(counselApiConfig.counselUserId),
+              result.threads,
+            );
+            const stillOnPlaceholder =
+              activeThreadRef.current.type === "counsel" &&
+              activeThreadRef.current.id === placeholderId;
+            setActiveThread((at) =>
+              at.type === "counsel" && at.id === placeholderId
+                ? { type: "counsel", id: result.newThread.id }
+                : at,
+            );
+            if (stillOnPlaceholder) {
+              setActiveCounselThreadId(result.newThread.id);
+            }
+          },
+          (err) =>
+            clientLogger.error({ err }, "Counsel thread list sync after iframe create failed"),
+        );
       } catch (error) {
-        clientLogger.error({ error }, "Failed to connect to Counsel");
+        clientLogger.error({ err: error }, "Failed to connect to Counsel");
       }
     },
-    [isLoading, getSignedUrl, addThread, invalidateThreads, hostThreads],
+    [
+      isLoading,
+      getSignedUrl,
+      addThread,
+      invalidateThreads,
+      hostThreads,
+      counselThreads,
+      counselApiConfig,
+      queryClient,
+    ],
   );
 
   // ---- Shared sidebar props -----------------------------------------------

--- a/web/nextjs/src/components/integrated/ChatInput.tsx
+++ b/web/nextjs/src/components/integrated/ChatInput.tsx
@@ -58,7 +58,7 @@ export default function ChatInput({ onSend, disabled, placeholder = "Type a mess
           onKeyDown={handleKeyDown}
           disabled={disabled}
           placeholder={placeholder}
-          className="flex-1 resize-none bg-transparent text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 outline-none min-h-[28px] max-h-[200px] leading-relaxed disabled:opacity-50"
+          className="flex-1 resize-none bg-transparent text-[16px] sm:text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 outline-none min-h-[28px] max-h-[200px] leading-relaxed disabled:opacity-50"
           style={{ height: "28px" }}
         />
         <button

--- a/web/nextjs/src/hooks/useCounselApi.ts
+++ b/web/nextjs/src/hooks/useCounselApi.ts
@@ -57,6 +57,88 @@ async function fetchThreadsFromServer(config: CounselApiConfig): Promise<ThreadI
   return data.threads ?? [];
 }
 
+/**
+ * TODO(cleanup): Remove this polling path once Counsel supports either (1) creating a thread via HTTP
+ * before opening the iframe, or (2) a postMessage from the embed with the real `thread_id` after
+ * `create_thread` completes. Then replace callers with a single refetch or cache update from that source.
+ *
+ * Polls GET /threads until a row appears that was not in `baselineThreadIds` (iframe create_thread is async).
+ */
+const POLL_INITIAL_DELAY_MS = 250;
+const POLL_MAX_DELAY_MS = 4000;
+const POLL_DEADLINE_MS = 45_000;
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const t = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(t);
+      signal.removeEventListener("abort", onAbort);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort);
+  });
+}
+
+function pickNewestByActivity(threads: ThreadItem[]): ThreadItem {
+  return threads.reduce((best, t) =>
+    new Date(t.last_activity_time).getTime() > new Date(best.last_activity_time).getTime() ? t : best,
+  );
+}
+
+/**
+ * Refetches threads until the server returns at least one id not in `baselineThreadIds`, or deadline/abort.
+ * Delete this export and its private helpers once Counsel offers create-via-API or embed `thread_id` messaging
+ * (see TODO on the poll constants block in this file).
+ */
+export async function pollUntilNewCounselThread(
+  config: CounselApiConfig,
+  baselineThreadIds: ReadonlySet<string>,
+  signal: AbortSignal,
+): Promise<{ threads: ThreadItem[]; newThread: ThreadItem } | null> {
+  const started = Date.now();
+  let delay = POLL_INITIAL_DELAY_MS;
+  let firstAttempt = true;
+
+  while (Date.now() - started < POLL_DEADLINE_MS) {
+    if (signal.aborted) return null;
+
+    if (!firstAttempt) {
+      try {
+        await sleep(delay, signal);
+      } catch {
+        return null;
+      }
+      delay = Math.min(delay * 2, POLL_MAX_DELAY_MS);
+    }
+    firstAttempt = false;
+
+    if (signal.aborted) return null;
+
+    let threads: ThreadItem[];
+    try {
+      threads = await fetchThreadsFromServer(config);
+    } catch {
+      continue;
+    }
+
+    const newcomers = threads.filter((t) => !baselineThreadIds.has(t.id));
+    if (newcomers.length > 0) {
+      const newThread = pickNewestByActivity(newcomers);
+      return { threads, newThread };
+    }
+  }
+
+  return null;
+}
+
 async function fetchSignedUrlFromServer(
   config: CounselApiConfig,
   action?: SignedUrlAction,

--- a/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
+++ b/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
@@ -6,7 +6,7 @@ import { useCallback, type RefObject } from "react";
  */
 type SwitchThreadMessage = {
   type: "switch_thread";
-  threadId: string;
+  thread_id: string;
 };
 
 type CounselOutboundMessage = SwitchThreadMessage;
@@ -32,7 +32,7 @@ export function useCounselAppMessageHandler({ iframeRef, iframeOrigin }: Options
 
   const switchThread = useCallback(
     (threadId: string) => {
-      sendMessage({ type: "switch_thread", threadId });
+      sendMessage({ type: "switch_thread", thread_id: threadId });
     },
     [sendMessage],
   );

--- a/web/nextjs/src/lib/handlePromiseRejection.ts
+++ b/web/nextjs/src/lib/handlePromiseRejection.ts
@@ -1,0 +1,10 @@
+/**
+ * Runs a fire-and-forget async task and routes rejections to `onReject`.
+ * Use instead of `void (async () => { ... })()` so failures are not unhandled.
+ */
+export function handlePromiseRejection<T>(
+  operation: () => Promise<T>,
+  onReject: (reason: unknown) => void,
+): void {
+  void operation().catch(onReject);
+}

--- a/web/nextjs/src/lib/http.ts
+++ b/web/nextjs/src/lib/http.ts
@@ -13,7 +13,7 @@ export async function fetchWithRetry(
     try {
       return await fetch(url, options);
     } catch (error) {
-      httpLogger.warn({ url, delay, error }, "Request failed, retrying");
+      httpLogger.warn({ url, delay, err: error }, "Request failed, retrying");
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
- Addresses thread switching bug
- Re-fetches new threads
- Fixes some mobile UX bugs
- Fixes some pino logger serialization stuff as well with a lint rule
- Turns off dark mode

#### Relevant Screenshots (if any)
<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->
##### Thread switching
https://github.com/user-attachments/assets/52a3cc2c-2749-4c0a-a8be-8491da475b93

##### Hand-off 
https://github.com/user-attachments/assets/e6c87206-fd72-49f9-aaec-823ad63981ca

##### Mobile UX
<img width="351" height="716" alt="Screenshot 2026-04-13 at 1 33 43 PM" src="https://github.com/user-attachments/assets/fb90d4e4-a211-400b-ba21-74dd9ad9a07b" />
<img width="384" height="715" alt="Screenshot 2026-04-13 at 1 33 39 PM" src="https://github.com/user-attachments/assets/71e7ad79-76ed-4b70-bc21-31e2e0f77e30" />

##### Dark mode
<img width="3248" height="1970" alt="image" src="https://github.com/user-attachments/assets/3fa09122-7eef-4ced-8120-ebf80a611c56" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes integrated chat thread creation/switching behavior with new polling/abort logic and directly manipulates the react-query cache; logging key changes are low risk but touch multiple error paths.
> 
> **Overview**
> Pins GitHub Actions Bun usage to `1.3.11` for more reproducible CI.
> 
> Improves the integrated chat UX and correctness by fixing Counsel iframe thread switching (uses `thread_id` in postMessage), adding a temporary poll/abort flow to reconcile newly-created Counsel threads into the sidebar/react-query cache, and tweaking mobile layout/input sizing for better mobile behavior.
> 
> Standardizes error logging for Pino serialization by adding a custom `oxlint` plugin/rule in both `server/nodejs` and `web/nextjs`, and updating affected logs to use `{ err }` instead of `{ error }` when logging Error instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04935eb9cbdc60ceb72eb81dadb19e26889352ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->