### PR TITLE
Update thread list immediately when new thread is created

### DIFF
--- a/automation-testing/README.md
+++ b/automation-testing/README.md
@@ -31,14 +31,14 @@ bun run test:e2e:api   # or test:e2e:ui / test:e2e
 
 ## Environment
 
-| Variable          | Role                                   | Default                 |
-| ----------------- | -------------------------------------- | ----------------------- |
-| `API_BASE_URL`    | Express API (must already be running)  | `http://127.0.0.1:4003` |
-| `WEB_BASE_URL`    | Next.js (must already be running)      | `http://127.0.0.1:3001` |
-| `CI`              | Set by CI (workers, retries, headless) | —                       |
-| `HEADLESS`        | `true` → headless browser (local UI)   | —                       |
-| `E2E_ACCESS_CODE` | Required for embedded-flow login test  | —                       |
-| `E2E_ACCESS_CODE_INTEGRATED` | Optional; access code with `navMode: integrated` for [integrated-handoff](ui/integrated-handoff.spec.ts). If unset, falls back to `E2E_ACCESS_CODE` (CI) then `AICHAT` | — |
+| Variable                     | Role                                                                                                                                                                   | Default                 |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `API_BASE_URL`               | Express API (must already be running)                                                                                                                                  | `http://127.0.0.1:4003` |
+| `WEB_BASE_URL`               | Next.js (must already be running)                                                                                                                                      | `http://127.0.0.1:3001` |
+| `CI`                         | Set by CI (workers, retries, headless)                                                                                                                                 | —                       |
+| `HEADLESS`                   | `true` → headless browser (local UI)                                                                                                                                   | —                       |
+| `E2E_ACCESS_CODE`            | Required for embedded-flow login test                                                                                                                                  | —                       |
+| `E2E_ACCESS_CODE_INTEGRATED` | Optional; access code with `navMode: integrated` for [integrated-handoff](ui/integrated-handoff.spec.ts). If unset, falls back to `E2E_ACCESS_CODE` (CI) then `AICHAT` | —                       |
 
 ## CI
 

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -7,7 +7,7 @@ import {
   useCounselThreads,
   type CounselApiConfig,
 } from "@/hooks/useCounselApi";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { PanelLeftOpen } from "lucide-react";
 import {
   Sheet,
@@ -18,6 +18,7 @@ import ChatList from "./integrated/ChatList";
 import ChatThread from "./integrated/ChatThread";
 import CounselChatThread from "./integrated/CounselChatThread";
 import type { HostThread } from "./integrated/types";
+import type { CounselInboundMessage } from "@/hooks/useCounselAppMessageHandler";
 
 // ---------------------------------------------------------------------------
 // Trigger phrase — any message containing this (case-insensitive) will show
@@ -107,6 +108,27 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
   } = useCounselThreads(counselApiConfig);
   const { getSignedUrl, isPending: isLoading } = useCounselSignedUrl(counselApiConfig);
 
+  // Sync state when Counsel iframe emits thread events
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent<CounselInboundMessage>) => {
+      const data = event.data;
+      if (!data || typeof data !== "object") return;
+
+      if (data.type === "counsel:thread_created" || data.type === "counsel:thread_updated") {
+        invalidateThreads();
+      } else if (data.type === "counsel:thread_selected" && "threadId" in data) {
+        const threadId = data.threadId;
+        setActiveThread({ type: "counsel", id: threadId });
+        setActiveCounselThreadId(threadId);
+        // Refresh sidebar metadata if it was a new internal thread
+        invalidateThreads();
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [invalidateThreads]);
+
   // ---- Handlers -----------------------------------------------------------
 
   const handleHostThreadClick = useCallback(
@@ -144,18 +166,18 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
 
   const handleNewChat = useCallback(() => {
     if (isLoading) return;
-    // Reuse an existing empty host thread (only the initial bot message, no user messages)
-    setHostThreads((prev) => {
-      const empty = prev.find((t) => t.messages.every((m) => m.role === "bot"));
-      if (empty) {
-        setActiveThread({ type: "host", id: empty.id });
-        return prev;
-      }
+
+    // First find if there's an existing empty host thread
+    const emptyThread = hostThreads.find((t) => t.messages.every((m) => m.role === "bot"));
+
+    if (emptyThread) {
+      setActiveThread({ type: "host", id: emptyThread.id });
+    } else {
       const newThread = createNewHostThread();
+      setHostThreads((prev) => [newThread, ...prev]);
       setActiveThread({ type: "host", id: newThread.id });
-      return [newThread, ...prev];
-    });
-  }, [isLoading]);
+    }
+  }, [isLoading, hostThreads]);
 
   const handleSendMessage = useCallback((threadId: string, text: string) => {
     const isTrigger = text.toLowerCase().includes(COUNSEL_TRIGGER);
@@ -221,7 +243,6 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
         setActiveThread({ type: "counsel", id: placeholderId });
         setCounselSessionUrl(url);
         setActiveCounselThreadId(null);
-        invalidateThreads();
       } catch (error) {
         clientLogger.error({ error }, "Failed to connect to Counsel");
       }

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -121,13 +121,7 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
       const data = event.data;
       if (!data || typeof data !== "object") return;
 
-      if (data.type === "counsel:thread_created" || data.type === "counsel:thread_updated") {
-        invalidateThreads();
-      } else if (data.type === "counsel:thread_selected" && "threadId" in data) {
-        const threadId = data.threadId;
-        setActiveThread({ type: "counsel", id: threadId });
-        setActiveCounselThreadId(threadId);
-        // Refresh sidebar metadata if it was a new internal thread
+      if (data.type === "counsel:thread_created") {
         invalidateThreads();
       }
     };

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -108,9 +108,20 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
   } = useCounselThreads(counselApiConfig);
   const { getSignedUrl, isPending: isLoading } = useCounselSignedUrl(counselApiConfig);
 
-  // Sync state when Counsel iframe emits thread events
+  // Sync state when Counsel iframe emits thread events (same origin check as outbound postMessage)
   useEffect(() => {
+    if (!counselSessionUrl) return;
+
+    let expectedOrigin: string;
+    try {
+      expectedOrigin = new URL(counselSessionUrl).origin;
+    } catch {
+      return;
+    }
+
     const handleMessage = (event: MessageEvent<CounselInboundMessage>) => {
+      if (event.origin !== expectedOrigin) return;
+
       const data = event.data;
       if (!data || typeof data !== "object") return;
 
@@ -127,7 +138,7 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [invalidateThreads]);
+  }, [counselSessionUrl, invalidateThreads]);
 
   // ---- Handlers -----------------------------------------------------------
 

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/hooks/useCounselApi";
 import { clientLogger } from "@/lib/clientLogger";
 import { PanelLeftOpen } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ChatList from "./integrated/ChatList";
 import ChatThread from "./integrated/ChatThread";
 import CounselChatThread from "./integrated/CounselChatThread";
@@ -89,6 +89,8 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
     type: "host",
     id: defaultThread.id,
   });
+  const activeThreadRef = useRef<ActiveThread>(activeThread);
+  activeThreadRef.current = activeThread;
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   // The signed URL currently loaded in the Counsel iframe. Kept stable so the
   // iframe is not reloaded unnecessarily — switching threads uses switch_thread.
@@ -122,7 +124,19 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
       if (!data || typeof data !== "object") return;
 
       if (data.type === "counsel:thread_created") {
+        const realId =
+          typeof data.threadId === "string" && data.threadId.length > 0 ? data.threadId : null;
         invalidateThreads();
+
+        const at = activeThreadRef.current;
+        if (
+          realId &&
+          at.type === "counsel" &&
+          at.id.startsWith("counsel-new-")
+        ) {
+          setActiveThread({ type: "counsel", id: realId });
+          setActiveCounselThreadId(realId);
+        }
       }
     };
 

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -176,20 +176,16 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
 
   const handleNewChat = useCallback(() => {
     if (isLoading) return;
-    let targetId: string | undefined;
     setHostThreads((prev) => {
       const existing = prev.find((t) => t.messages.every((m) => m.role === "bot"));
       if (existing) {
-        targetId = existing.id;
+        setActiveThread({ type: "host", id: existing.id });
         return prev;
       }
       const newThread = createNewHostThread();
-      targetId = newThread.id;
+      setActiveThread({ type: "host", id: newThread.id });
       return [newThread, ...prev];
     });
-    if (targetId) {
-      setActiveThread({ type: "host", id: targetId });
-    }
   }, [isLoading]);
 
   const handleSendMessage = useCallback((threadId: string, text: string) => {

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -247,7 +247,7 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
         clientLogger.error({ error }, "Failed to connect to Counsel");
       }
     },
-    [isLoading, getSignedUrl, addThread, invalidateThreads, hostThreads],
+    [isLoading, getSignedUrl, addThread, hostThreads],
   );
 
   // ---- Shared sidebar props -----------------------------------------------

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -174,17 +174,19 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
   const handleNewChat = useCallback(() => {
     if (isLoading) return;
 
-    // First find if there's an existing empty host thread
-    const emptyThread = hostThreads.find((t) => t.messages.every((m) => m.role === "bot"));
-
-    if (emptyThread) {
-      setActiveThread({ type: "host", id: emptyThread.id });
-    } else {
+    // Use the functional updater so rapid "New Chat" clicks always see the latest
+    // thread list; a closure over `hostThreads` can be stale before the next render.
+    setHostThreads((prev) => {
+      const empty = prev.find((t) => t.messages.every((m) => m.role === "bot"));
+      if (empty) {
+        setActiveThread({ type: "host", id: empty.id });
+        return prev;
+      }
       const newThread = createNewHostThread();
-      setHostThreads((prev) => [newThread, ...prev]);
       setActiveThread({ type: "host", id: newThread.id });
-    }
-  }, [isLoading, hostThreads]);
+      return [newThread, ...prev];
+    });
+  }, [isLoading]);
 
   const handleSendMessage = useCallback((threadId: string, text: string) => {
     const isTrigger = text.toLowerCase().includes(COUNSEL_TRIGGER);

--- a/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
+++ b/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
@@ -16,8 +16,6 @@ type CounselOutboundMessage = SwitchThreadMessage;
  */
 export type CounselInboundMessage =
   | { type: "counsel:thread_created"; threadId: string }
-  | { type: "counsel:thread_updated"; threadId: string }
-  | { type: "counsel:thread_selected"; threadId: string };
 
 
 type Options = {

--- a/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
+++ b/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
@@ -15,7 +15,7 @@ type CounselOutboundMessage = SwitchThreadMessage;
  * Inbound message types emitted by the Counsel iframe.
  */
 export type CounselInboundMessage =
-  | { type: "counsel:thread_created"; threadId: string }
+  | { type: "counsel:thread_created"; thread_id: string }
 
 
 type Options = {

--- a/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
+++ b/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
@@ -41,7 +41,7 @@ export function useCounselAppMessageHandler({ iframeRef, iframeOrigin }: Options
 
   const switchThread = useCallback(
     (threadId: string) => {
-      sendMessage({ type: "switch_thread", threadId });
+      sendMessage({ type: "switch_thread", thread_id: threadId });
     },
     [sendMessage],
   );

--- a/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
+++ b/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
@@ -6,10 +6,19 @@ import { useCallback, type RefObject } from "react";
  */
 type SwitchThreadMessage = {
   type: "switch_thread";
-  threadId: string;
+  thread_id: string;
 };
 
 type CounselOutboundMessage = SwitchThreadMessage;
+
+/**
+ * Inbound message types emitted by the Counsel iframe.
+ */
+export type CounselInboundMessage =
+  | { type: "counsel:thread_created"; threadId: string }
+  | { type: "counsel:thread_updated"; threadId: string }
+  | { type: "counsel:thread_selected"; threadId: string };
+
 
 type Options = {
   iframeRef: RefObject<HTMLIFrameElement | null>;


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
* Update thread list immediately once a Counsel thread has been created
* Ensure the new thread button creates a new thread on first press
* Switch `threadId` to `thread_id`

#### Notes & Questions for Reviewer
<!-- Highlight anything noteworthy that the reviewer should pay
extra attention to. -->

#### Relevant Screenshots (if any)
<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds cross-window `postMessage` handling and thread cache invalidation in the integrated chat flow, which can affect thread navigation/state if origins or message shapes are wrong. Also changes host-thread creation/removal behavior, so regressions would show up as UI state bugs rather than backend issues.
> 
> **Overview**
> **Integrated chat now reacts to Counsel iframe events to keep the sidebar in sync.** `IntegratedChatPage` listens for `counsel:thread_created` messages (origin-checked against the signed iframe URL) and calls `invalidateThreads()` so newly created Counsel threads appear immediately.
> 
> It also adjusts thread UX/state handling: `handleNewChat` now uses a functional state update to ensure the first click reliably creates/activates a new host thread, and connecting to Counsel no longer removes the host thread but instead hides the Counsel card on that thread while immediately `addThread()`-ing the new Counsel thread. `useCounselAppMessageHandler` exports a new `CounselInboundMessage` type for typed inbound events, and the E2E README’s environment table formatting is cleaned up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d423bf5746eb613223b014b6d46d3f4b89d0156e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->