### PR TITLE
#COU-6392(chore) - integrate new threads api + UI bug fixes

### DIFF
--- a/automation-testing/ui/integrated-handoff.spec.ts
+++ b/automation-testing/ui/integrated-handoff.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Response } from "@playwright/test";
 
 // Prefer a code with navMode: integrated; otherwise use the same JWT code as embedded-flow (CI sets E2E_ACCESS_CODE).
 const accessCode =
@@ -34,14 +34,27 @@ test.describe("integrated chat - connect to care handoff", () => {
       page.getByRole("button", { name: "Connect to Counsel" })
     ).toBeVisible();
 
+    // The handoff flow now creates a thread via API first, then opens it via signedAppUrl.
+    const createThreadResponse = page.waitForResponse(
+      (resp: Response) =>
+        resp.url().includes("/threads") &&
+        resp.request().method() === "POST" &&
+        resp.request().resourceType() === "fetch"
+    );
     const signedUrlResponse = page.waitForResponse(
-      (resp) =>
+      (resp: Response) =>
         resp.url().includes("/signedAppUrl") &&
         resp.request().method() === "POST" &&
         resp.request().resourceType() === "fetch"
     );
 
     await page.getByRole("button", { name: "Connect to Counsel" }).click();
+
+    const threadResponse = await createThreadResponse;
+    expect(
+      threadResponse.ok(),
+      `POST /threads failed: ${threadResponse.status()}`
+    ).toBe(true);
 
     const response = await signedUrlResponse;
     expect(response.ok(), `signedAppUrl failed: ${response.status()}`).toBe(

--- a/server/nodejs/src/lib/counsel.ts
+++ b/server/nodejs/src/lib/counsel.ts
@@ -96,6 +96,49 @@ export async function getCounselUserThreads({
   return await response.json();
 }
 
+const CreateThreadResponse = z.object({
+  thread_id: z.string(),
+  created_at: z.string(),
+});
+
+export async function createCounselThread({
+  userId,
+  accessCode,
+  body,
+}: {
+  userId: string;
+  accessCode: string;
+  body: {
+    module?: string;
+    initial_messages?: Array<{ body: string; role?: "patient" | "model" }>;
+    agent_context?: Record<string, unknown>;
+  };
+}) {
+  const apiUrl = getApiUrl(accessCode);
+  const response = await fetchWithRetry(
+    getRequestUrl(apiUrl, `/v1/user/${userId}/threads`),
+    {
+      method: "POST",
+      headers: await getRequestHeaders(accessCode),
+      body: JSON.stringify(body),
+    }
+  );
+  if (!response.ok) {
+    const detail = await readHttpErrorDetail(response);
+    counselLogger.error(
+      { status: response.status, detail },
+      "Counsel API create thread failed"
+    );
+    throw new Error(
+      `Request to create thread failed: ${response.status} ${
+        response.statusText
+      }${detail ? ` ${detail}` : ""}`
+    );
+  }
+  const data = await response.json();
+  return CreateThreadResponse.parse(data);
+}
+
 export async function getCounselSignedAppUrl({
   userId,
   accessCode,

--- a/server/nodejs/src/routes/user/threads/index.ts
+++ b/server/nodejs/src/routes/user/threads/index.ts
@@ -1,6 +1,7 @@
 import { getOrCreateUser } from "../signedAppUrl";
-import { getCounselUserThreads } from "@/lib/counsel";
+import { getCounselUserThreads, createCounselThread } from "@/lib/counsel";
 import type { User } from "@/lib/user-session";
+import { z } from "zod";
 
 /**
  * @description Get the user's chat threads from the Counsel API
@@ -13,4 +14,42 @@ export async function threadsHandler({ user }: { user: User }) {
     accessCode: user.accessCode,
   });
   return threads;
+}
+
+export const CreateThreadBodySchema = z.object({
+  module: z.string().optional(),
+  initial_messages: z
+    .array(
+      z.object({
+        body: z.string(),
+        role: z.enum(["patient", "model"]).optional(),
+      })
+    )
+    .max(10)
+    .optional(),
+  agent_context: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const CreateThreadResponseSchema = z.object({
+  thread_id: z.string(),
+  created_at: z.string(),
+});
+
+/**
+ * @description Create a new thread for the user via the Counsel API
+ * @route POST /user/threads
+ */
+export async function createThreadHandler({
+  user,
+  body,
+}: {
+  user: User;
+  body: z.infer<typeof CreateThreadBodySchema>;
+}) {
+  const u = await getOrCreateUser(user.userId, user.accessCode);
+  return await createCounselThread({
+    userId: u.counsel_user_id,
+    accessCode: user.accessCode,
+    body,
+  });
 }

--- a/server/nodejs/src/routes/user/userRoutes.ts
+++ b/server/nodejs/src/routes/user/userRoutes.ts
@@ -3,8 +3,17 @@ import { Elysia } from "elysia";
 import { z } from "zod";
 import { signOutHandler } from "./signOut";
 import { SignUpBodySchema, signUpHandler, SignUpResponseSchema } from "./signUp";
-import { SessionDataSchema, signedAppUrlHandler, SignedAppUrlResponseSchema } from "./signedAppUrl";
-import { threadsHandler } from "./threads";
+import {
+  SessionDataSchema,
+  signedAppUrlHandler,
+  SignedAppUrlResponseSchema,
+} from "./signedAppUrl";
+import {
+  CreateThreadBodySchema,
+  createThreadHandler,
+  CreateThreadResponseSchema,
+  threadsHandler,
+} from "./threads";
 
 export const UserPlugin = new Elysia({ prefix: "/user" })
   // public — no auth required; body validated by Elysia before handler runs
@@ -17,8 +26,14 @@ export const UserPlugin = new Elysia({ prefix: "/user" })
   .post("/signOut", ({ user }) => signOutHandler({ user }), {
     response: z.object({ status: z.literal("ok") }),
   })
-  .post("/signedAppUrl", ({ user, body }) => signedAppUrlHandler({ user, body }), {
-    body: SessionDataSchema,
-    response: SignedAppUrlResponseSchema,
-  })
-  .get("/threads", ({ user }) => threadsHandler({ user }));
+  .post(
+    "/signedAppUrl",
+    ({ user, body }) => signedAppUrlHandler({ user, body }),
+    { body: SessionDataSchema, response: SignedAppUrlResponseSchema }
+  )
+  .get("/threads", ({ user }) => threadsHandler({ user }))
+  .post(
+    "/threads",
+    ({ user, body }) => createThreadHandler({ user, body }),
+    { body: CreateThreadBodySchema, response: CreateThreadResponseSchema }
+  );

--- a/web/nextjs/src/app/api/counsel/threads/route.ts
+++ b/web/nextjs/src/app/api/counsel/threads/route.ts
@@ -25,3 +25,33 @@ export async function GET() {
     headers: { "Content-Type": "application/json" },
   });
 }
+
+/**
+ * Proxies POST /v1/user/:id/threads to create a new thread.
+ *
+ * Only used in API key mode — the browser cannot hold the secret, so it
+ * proxies through here → demo server → Counsel API.
+ * In JWT mode the browser calls the Counsel API directly and never hits this route.
+ */
+export async function POST(req: Request) {
+  const session = await getSession();
+  if (!session.token || !session.counselUserId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const requestBody = await req.json();
+
+  const resp = await fetchWithRetry(`${serverEnv.SERVER_HOST}/user/threads`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`,
+    },
+    body: JSON.stringify(requestBody),
+  });
+  const body = await resp.text();
+  return new Response(body, {
+    status: resp.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -2,18 +2,15 @@
 
 import { signOut } from "@/actions/signOut";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
-import { counselQueryKeys } from "@/hooks/counselQueryKeys";
 import {
-  pollUntilNewCounselThread,
+  useCounselCreateThread,
   useCounselSignedUrl,
   useCounselThreads,
   type CounselApiConfig,
 } from "@/hooks/useCounselApi";
 import { clientLogger } from "@/lib/clientLogger";
-import { handlePromiseRejection } from "@/lib/handlePromiseRejection";
-import { useQueryClient } from "@tanstack/react-query";
 import { PanelLeftOpen } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import ChatList from "./integrated/ChatList";
 import ChatThread from "./integrated/ChatThread";
 import CounselChatThread from "./integrated/CounselChatThread";
@@ -92,8 +89,6 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
     type: "host",
     id: defaultThread.id,
   });
-  const activeThreadRef = useRef<ActiveThread>(activeThread);
-  activeThreadRef.current = activeThread;
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   // The signed URL currently loaded in the Counsel iframe. Kept stable so the
   // iframe is not reloaded unnecessarily — switching threads uses switch_thread.
@@ -101,21 +96,14 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
   // When set, triggers a counsel:switchThread postMessage to the live iframe.
   const [activeCounselThreadId, setActiveCounselThreadId] = useState<string | null>(null);
 
-  const queryClient = useQueryClient();
   const {
     threads: counselThreads,
     isLoading: isThreadsLoading,
     addThread,
-    invalidateThreads,
   } = useCounselThreads(counselApiConfig);
-  const { getSignedUrl, isPending: isLoading } = useCounselSignedUrl(counselApiConfig);
-
-  const threadPollAbortRef = useRef<AbortController | null>(null);
-  useEffect(() => {
-    return () => {
-      threadPollAbortRef.current?.abort();
-    };
-  }, []);
+  const { getSignedUrl, isPending: isSignedUrlPending } = useCounselSignedUrl(counselApiConfig);
+  const { createThread, isPending: isCreateThreadPending } = useCounselCreateThread(counselApiConfig);
+  const isLoading = isSignedUrlPending || isCreateThreadPending;
 
   // ---- Handlers -----------------------------------------------------------
 
@@ -132,18 +120,15 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
       if (isLoading) return;
       setActiveThread({ type: "counsel", id: threadId });
 
+      // If the iframe is already loaded, switch threads via postMessage (no reload)
       if (counselSessionUrl) {
-        if (!threadId.startsWith("counsel-new-")) {
-          setActiveCounselThreadId(threadId);
-        }
+        setActiveCounselThreadId(threadId);
         return;
       }
 
+      // First Counsel thread click — get a signed URL with open_thread
       try {
-        const isPlaceholder = threadId.startsWith("counsel-new-");
-        const url = isPlaceholder
-          ? await getSignedUrl({ action: "create_thread" })
-          : await getSignedUrl({ action: "open_thread", thread_id: threadId });
+        const url = await getSignedUrl({ action: "open_thread", thread_id: threadId });
         setCounselSessionUrl(url);
       } catch (error) {
         clientLogger.error({ err: error }, "Failed to load Counsel thread");
@@ -154,17 +139,20 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
 
   const handleNewChat = useCallback(() => {
     if (isLoading) return;
-    // Reuse an existing empty host thread (only the initial bot message, no user messages)
+    let targetId: string | undefined;
     setHostThreads((prev) => {
-      const empty = prev.find((t) => t.messages.every((m) => m.role === "bot"));
-      if (empty) {
-        setActiveThread({ type: "host", id: empty.id });
+      const existing = prev.find((t) => t.messages.every((m) => m.role === "bot"));
+      if (existing) {
+        targetId = existing.id;
         return prev;
       }
       const newThread = createNewHostThread();
-      setActiveThread({ type: "host", id: newThread.id });
+      targetId = newThread.id;
       return [newThread, ...prev];
     });
+    if (targetId) {
+      setActiveThread({ type: "host", id: targetId });
+    }
   }, [isLoading]);
 
   const handleSendMessage = useCallback((threadId: string, text: string) => {
@@ -211,81 +199,53 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
         const reason_for_handoff =
           lastUserMessage?.text ?? "Agent detected a need for medical assistance";
 
-        const url = await getSignedUrl({
-          action: "create_thread",
+        // Show loading state while keeping the host thread in state until success.
+        // Clear activeCounselThreadId so the existing iframe (if any) doesn't briefly flash
+        // the old thread while we create the new one.
+        setActiveCounselThreadId(null);
+        setActiveThread({ type: "counsel", id: `counsel-loading-${Date.now()}` });
+
+        // 1. Create the thread via API — returns immediately with thread_id
+        const { thread_id } = await createThread({
           initial_messages,
           agent_context: { reason_for_handoff },
         });
 
-        const baselineThreadIds = new Set(counselThreads.map((t) => t.id));
+        // 2. If the iframe is already loaded, switch to the new thread via postMessage
+        //    (no need for a new signed URL). Otherwise get one to bootstrap the iframe.
+        if (!counselSessionUrl) {
+          const url = await getSignedUrl({
+            action: "open_thread",
+            thread_id,
+          });
+          setCounselSessionUrl(url);
+        }
 
-        setHostThreads((prev) =>
-          prev.map((t) => (t.id === hostThreadId ? { ...t, showCounselCard: false } : t)),
-        );
+        // Success — now safe to remove the host thread since the counsel thread replaces it.
+        setHostThreads((prev) => prev.filter((t) => t.id !== hostThreadId));
 
-        const placeholderId = `counsel-new-${Date.now()}`;
+        // Add the real thread to the sidebar immediately (no placeholder/polling needed)
         addThread({
-          id: placeholderId,
+          id: thread_id,
           display_name: "Counsel chat",
           last_activity_time: new Date().toISOString(),
           mode: "ai",
         });
-        setActiveThread({ type: "counsel", id: placeholderId });
-        setCounselSessionUrl(url);
-        setActiveCounselThreadId(null);
-
-        threadPollAbortRef.current?.abort();
-        threadPollAbortRef.current = new AbortController();
-        const signal = threadPollAbortRef.current.signal;
-
-        // TODO(cleanup): Drop this block when `pollUntilNewCounselThread` is removed (server create or embed message).
-        handlePromiseRejection(
-          async () => {
-            const result = await pollUntilNewCounselThread(
-              counselApiConfig,
-              baselineThreadIds,
-              signal,
-            );
-            if (signal.aborted) return;
-            if (!result) {
-              clientLogger.warn(
-                "Timed out waiting for new Counsel thread; sidebar may be stale until refresh",
-              );
-              await invalidateThreads();
-              return;
-            }
-            queryClient.setQueryData(
-              counselQueryKeys.threads(counselApiConfig.counselUserId),
-              result.threads,
-            );
-            const stillOnPlaceholder =
-              activeThreadRef.current.type === "counsel" &&
-              activeThreadRef.current.id === placeholderId;
-            setActiveThread((at) =>
-              at.type === "counsel" && at.id === placeholderId
-                ? { type: "counsel", id: result.newThread.id }
-                : at,
-            );
-            if (stillOnPlaceholder) {
-              setActiveCounselThreadId(result.newThread.id);
-            }
-          },
-          (err) =>
-            clientLogger.error({ err }, "Counsel thread list sync after iframe create failed"),
-        );
+        setActiveThread({ type: "counsel", id: thread_id });
+        setActiveCounselThreadId(thread_id);
       } catch (error) {
         clientLogger.error({ err: error }, "Failed to connect to Counsel");
+        // Restore the host thread view so the user's conversation isn't lost
+        setActiveThread({ type: "host", id: hostThreadId });
       }
     },
     [
       isLoading,
+      createThread,
       getSignedUrl,
       addThread,
-      invalidateThreads,
       hostThreads,
-      counselThreads,
-      counselApiConfig,
-      queryClient,
+      counselSessionUrl,
     ],
   );
 
@@ -351,9 +311,15 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
             />
           )}
 
+          {activeThread.type === "counsel" && isLoading && (
+            <div className="flex items-center justify-center h-full">
+              <div className="size-8 border-2 border-zinc-300 border-t-blue-500 rounded-full animate-spin" />
+            </div>
+          )}
+
           {counselSessionUrl && (
             <CounselChatThread
-              hidden={activeThread.type !== "counsel"}
+              hidden={activeThread.type !== "counsel" || isLoading}
               signedAppUrl={counselSessionUrl}
               currentThreadId={activeCounselThreadId ?? undefined}
             />

--- a/web/nextjs/src/hooks/useCounselApi.ts
+++ b/web/nextjs/src/hooks/useCounselApi.ts
@@ -1,4 +1,4 @@
-import type { ThreadItem } from "@/lib/schemas";
+import type { CreateThreadResponse, ThreadItem } from "@/lib/schemas";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { counselQueryKeys } from "./counselQueryKeys";
@@ -55,90 +55,6 @@ async function fetchThreadsFromServer(config: CounselApiConfig): Promise<ThreadI
   return data.threads ?? [];
 }
 
-/**
- * TODO(cleanup): Remove this polling path once Counsel supports either (1) creating a thread via HTTP
- * before opening the iframe, or (2) a postMessage from the embed with the real `thread_id` after
- * `create_thread` completes. Then replace callers with a single refetch or cache update from that source.
- *
- * Polls GET /threads until a row appears that was not in `baselineThreadIds` (iframe create_thread is async).
- */
-const POLL_INITIAL_DELAY_MS = 250;
-const POLL_MAX_DELAY_MS = 4000;
-const POLL_DEADLINE_MS = 45_000;
-
-function sleep(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal.aborted) {
-      reject(new DOMException("Aborted", "AbortError"));
-      return;
-    }
-    const t = setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(t);
-      signal.removeEventListener("abort", onAbort);
-      reject(new DOMException("Aborted", "AbortError"));
-    };
-    signal.addEventListener("abort", onAbort);
-  });
-}
-
-function pickNewestByActivity(threads: ThreadItem[]): ThreadItem {
-  return threads.reduce((best, t) =>
-    new Date(t.last_activity_time).getTime() > new Date(best.last_activity_time).getTime()
-      ? t
-      : best,
-  );
-}
-
-/**
- * Refetches threads until the server returns at least one id not in `baselineThreadIds`, or deadline/abort.
- * Delete this export and its private helpers once Counsel offers create-via-API or embed `thread_id` messaging
- * (see TODO on the poll constants block in this file).
- */
-export async function pollUntilNewCounselThread(
-  config: CounselApiConfig,
-  baselineThreadIds: ReadonlySet<string>,
-  signal: AbortSignal,
-): Promise<{ threads: ThreadItem[]; newThread: ThreadItem } | null> {
-  const started = Date.now();
-  let delay = POLL_INITIAL_DELAY_MS;
-  let firstAttempt = true;
-
-  while (Date.now() - started < POLL_DEADLINE_MS) {
-    if (signal.aborted) return null;
-
-    if (!firstAttempt) {
-      try {
-        await sleep(delay, signal);
-      } catch {
-        return null;
-      }
-      delay = Math.min(delay * 2, POLL_MAX_DELAY_MS);
-    }
-    firstAttempt = false;
-
-    if (signal.aborted) return null;
-
-    let threads: ThreadItem[];
-    try {
-      threads = await fetchThreadsFromServer(config);
-    } catch {
-      continue;
-    }
-
-    const newcomers = threads.filter((t) => !baselineThreadIds.has(t.id));
-    if (newcomers.length > 0) {
-      const newThread = pickNewestByActivity(newcomers);
-      return { threads, newThread };
-    }
-  }
-
-  return null;
-}
-
 async function fetchSignedUrlFromServer(
   config: CounselApiConfig,
   action?: SignedUrlAction,
@@ -182,6 +98,43 @@ async function fetchSignedUrlFromServer(
   }
   const { url } = await resp.json();
   return url;
+}
+
+// ---------------------------------------------------------------------------
+// Create thread
+// ---------------------------------------------------------------------------
+
+export type CreateThreadParams = {
+  module?: string;
+  initial_messages?: InitialMessage[];
+  agent_context?: Record<string, unknown>;
+};
+
+async function createThreadOnServer(
+  config: CounselApiConfig,
+  params: CreateThreadParams,
+): Promise<CreateThreadResponse> {
+  const direct = config.counselJwt.length > 0;
+  const url = direct
+    ? `${config.counselDirectApiBase}/threads`
+    : "/api/counsel/threads";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Idempotency-Key": crypto.randomUUID(),
+  };
+  if (direct) {
+    headers.Authorization = `Bearer ${config.counselJwt}`;
+  }
+  const resp = await fetch(url, {
+    method: "POST",
+    headers,
+    credentials: direct ? "omit" : "include",
+    body: JSON.stringify(params),
+  });
+  if (!resp.ok) {
+    throw new Error(`Failed to create thread: ${resp.status}`);
+  }
+  return resp.json();
 }
 
 // ---------------------------------------------------------------------------
@@ -231,4 +184,17 @@ export function useCounselSignedUrl(config: CounselApiConfig) {
   });
 
   return { getSignedUrl: mutateAsync, isPending };
+}
+
+/**
+ * Returns a `createThread` function that creates a thread via the Counsel API,
+ * then returns the thread_id. Use this before calling `getSignedUrl` with
+ * `open_thread` to load the iframe faster.
+ */
+export function useCounselCreateThread(config: CounselApiConfig) {
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: (params: CreateThreadParams) => createThreadOnServer(config, params),
+  });
+
+  return { createThread: mutateAsync, isPending };
 }

--- a/web/nextjs/src/lib/schemas.ts
+++ b/web/nextjs/src/lib/schemas.ts
@@ -21,6 +21,13 @@ export const ThreadListResponseSchema = z.object({
 
 export type ThreadItem = z.infer<typeof ThreadItemSchema>;
 
+export const CreateThreadResponseSchema = z.object({
+  thread_id: z.string(),
+  created_at: z.string(),
+});
+
+export type CreateThreadResponse = z.infer<typeof CreateThreadResponseSchema>;
+
 export const SignUpResponseSchema = z.object({
   token: z.string(),
   userType: z.enum(["main", "onboarding"]),


### PR DESCRIPTION
Fixes a bunch of stuff
- Adds loading screen
- Merges threads for now
- Broken mobile screen was showing blank screen
- Dont invalidate and refresh - feels kinda weird for every new thread seeing old thread update name

- Integrate open_thread


https://github.com/user-attachments/assets/5ff46a23-c1eb-4123-a11c-3b513e28b925


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new thread-creation API path across server and Next.js proxy and rewires the integrated handoff flow, which may affect Counsel session/iframe behavior and thread state consistency.
> 
> **Overview**
> Updates the integrated Counsel handoff to **create a thread via HTTP first** and then open it via `signedAppUrl` with `open_thread`, removing the previous placeholder/polling-based synchronization.
> 
> Adds `POST /user/threads` end-to-end: server-side `createCounselThread` + Elysia route validation, a Next.js `POST /api/counsel/threads` proxy for API-key sessions, and a new client hook `useCounselCreateThread` (with idempotency keys).
> 
> Improves the integrated chat UI flow by introducing a loading spinner during thread creation/open, switching threads via postMessage when the iframe is already loaded, and restoring the host thread view on failure; Playwright coverage is updated to assert both `POST /threads` and `POST /signedAppUrl` occur.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba00541cee47eb2e7ef3773e8ca60749722b4f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->