### PR TITLE
easy: fix issuer jwt auth + added loading state to threads menu

### DIFF
--- a/server/nodejs/src/__tests__/envConfig.test.ts
+++ b/server/nodejs/src/__tests__/envConfig.test.ts
@@ -12,12 +12,14 @@ describe("envConfig", () => {
           client: "main",
           apiUrl: "https://test-api.counselhealth.com",
           userType: "main",
+          apiKey: "sk_test_main01_key",
           issuer: "https://local-test-partner.example.com/main",
         },
         ONBR01: {
           client: "onboarding",
           apiUrl: "https://test-api.counselhealth.com",
           userType: "onboarding",
+          apiKey: "sk_test_onbr01_key",
           issuer: "https://local-test-partner.example.com/onboarding",
         },
       });
@@ -43,6 +45,7 @@ describe("envConfig", () => {
         MAIN01: {
           client: "main",
           apiUrl: "https://test-api.counselhealth.com",
+          apiKey: "sk_test_main01_key",
           issuer: "https://local-test-partner.example.com/main",
         },
       });
@@ -95,7 +98,7 @@ describe("envConfig", () => {
 
       expect(() =>
         envConfig.shape.ACCESS_CODE_CONFIGS.parse(invalidConfig)
-      ).toThrow(/apiKey or issuer/);
+      ).toThrow(/apiKey/);
     });
 
     test("should reject empty ACCESS_CODE_CONFIGS", () => {
@@ -112,18 +115,21 @@ describe("envConfig", () => {
           client: "main",
           apiUrl: "https://test-api.counselhealth.com",
           userType: "main",
+          apiKey: "sk_test_main01_key",
           issuer: "https://local-test-partner.example.com/main",
         },
         CLNT01: {
           client: "client1",
           apiUrl: "https://test-api.counselhealth.com",
           userType: "main",
+          apiKey: "sk_test_clnt01_key",
           issuer: "https://local-test-partner.example.com/client1",
         },
         CLNT02: {
           client: "client2",
           apiUrl: "https://test-api.counselhealth.com",
           userType: "onboarding",
+          apiKey: "sk_test_clnt02_key",
           issuer: "https://local-test-partner.example.com/client2",
         },
       });
@@ -159,12 +165,14 @@ describe("envConfig", () => {
           client: "main",
           apiUrl: "https://test-api.counselhealth.com",
           userType: "main",
+          apiKey: "sk_test_main01_key",
           issuer: "https://local-test-partner.example.com/main",
         },
         ONBR01: {
           client: "onboarding",
           apiUrl: "https://test-api.counselhealth.com",
           userType: "onboarding",
+          apiKey: "sk_test_onbr01_key",
           issuer: "https://local-test-partner.example.com/onboarding",
         },
       };

--- a/server/nodejs/src/app.ts
+++ b/server/nodejs/src/app.ts
@@ -1,9 +1,9 @@
 import { HttpError, UserFacingError, isHttpError } from "@/lib/http";
+import { httpLogger } from "@/lib/logger";
 import { observabilityPlugin } from "@/lib/observability";
 import { MainPlugin } from "@/routes";
 import { cors } from "@elysiajs/cors";
 import { Elysia, ValidationError } from "elysia";
-import { httpLogger } from "@/lib/logger";
 
 const SECURITY_HEADERS: Record<string, string> = {
   "X-Content-Type-Options": "nosniff",
@@ -46,27 +46,38 @@ const app = new Elysia()
     };
 
     const logCompletion = (statusCode: number) => {
-      const duration = requestStart ? `${(performance.now() - requestStart).toFixed(2)}ms` : "unknown";
-      httpLogger.info({ method, path, statusCode, duration, requestId: requestId ?? "no-id" }, "Request finished");
+      const duration = requestStart
+        ? `${(performance.now() - requestStart).toFixed(2)}ms`
+        : "unknown";
+      httpLogger.info(
+        { method, path, statusCode, duration, requestId: requestId ?? "no-id" },
+        "Request finished",
+      );
     };
 
     if (code === "VALIDATION") {
-      const isResponseFailure =
-        error instanceof ValidationError && error.type === "response";
+      const isResponseFailure = error instanceof ValidationError && error.type === "response";
 
       if (!(error instanceof ValidationError) || isResponseFailure) {
         set.status = 500;
         httpLogger.error(
-          { method, path, requestId: requestId ?? "no-id", error: error instanceof Error ? error.message : error },
+          {
+            method,
+            path,
+            requestId: requestId ?? "no-id",
+            error: error instanceof Error ? error.message : error,
+          },
           "Response or unknown validation failure",
         );
         logCompletion(500);
         return { errors: { message: "Internal Server Error" } };
       }
 
-      const clientMessage =
-        error.type === "body" ? "Invalid request body" : "Invalid request";
-      httpLogger.warn({ method, path, validationType: error.type, error: error.message }, "Validation error");
+      const clientMessage = error.type === "body" ? "Invalid request body" : "Invalid request";
+      httpLogger.warn(
+        { method, path, validationType: error.type, error: error.message },
+        "Validation error",
+      );
       set.status = 422;
       logCompletion(422);
       return { errors: { message: clientMessage } };

--- a/server/nodejs/src/envConfigSchema.ts
+++ b/server/nodejs/src/envConfigSchema.ts
@@ -4,25 +4,22 @@ import { z } from "zod";
 // Supports two auth modes:
 // - apiKey: API key auth (Bearer apiKey). Use when you have a Counsel API key.
 // - issuer: JWT auth only. Use with COUNSEL_PRIVATE_KEY_PEM for RSA-signed JWTs.
-// At least one of apiKey or issuer must be present.
-export const AccessCodeConfigSchema = z
-  .object({
-    client: z.string(),
-    apiUrl: z.string().url(),
-    userType: z.enum(["main", "onboarding"]).default("main"),
-    // Navigation mode for the embedded chat experience.
-    // "standalone" (default): full Counsel iframe with built-in sidebar
-    // "integrated": host-managed sidebar with Counsel integrated view (no Counsel sidebar)
-    navMode: z.enum(["standalone", "integrated"]).default("standalone"),
-    // API key for API key auth. When present, used as Bearer token.
-    apiKey: z.string().optional(),
-    // The iss claim put in JWTs for this access code's org.
-    // Required when apiKey is not present. Counsel maps this to the org in orgByIssuer.
-    issuer: z.string().url().optional(),
-  })
-  .refine((config) => config.apiKey ?? config.issuer, {
-    message: "Each access code config must have either apiKey or issuer",
-  });
+// At least one of apiKey or issuer must be present for Browser direct calls to the Counsel API.
+export const AccessCodeConfigSchema = z.object({
+  client: z.string(),
+  apiUrl: z.url(),
+  userType: z.enum(["main", "onboarding"]).default("main"),
+  // Navigation mode for the embedded chat experience.
+  // "standalone" (default): full Counsel iframe with built-in sidebar
+  // "integrated": host-managed sidebar with Counsel integrated view (no Counsel sidebar)
+  navMode: z.enum(["standalone", "integrated"]).default("standalone"),
+  // API key for API key auth. Needed for server→Counsel calls.
+  apiKey: z.string(),
+  // The iss claim put in JWTs for this access code's org.
+  // Required for Browser direct calls to the Counsel API.
+  // If skipped, all requests will be proxied through the demo server.
+  issuer: z.url().optional(),
+});
 
 // Environment configuration schema
 export const envConfig = z
@@ -45,11 +42,8 @@ export const envConfig = z
         try {
           return JSON.parse(val);
         } catch (error) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          throw new Error(
-            `ACCESS_CODE_CONFIGS must be valid JSON: ${errorMessage}`
-          );
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          throw new Error(`ACCESS_CODE_CONFIGS must be valid JSON: ${errorMessage}`);
         }
       })
       .pipe(
@@ -57,13 +51,11 @@ export const envConfig = z
           .record(z.string().length(6), AccessCodeConfigSchema)
           .refine((configs) => Object.keys(configs).length > 0, {
             message: "At least one access code configuration is required",
-          })
+          }),
       ),
   })
   .superRefine((data, ctx) => {
-    const hasIssuerConfig = Object.values(data.ACCESS_CODE_CONFIGS).some(
-      (c) => c.issuer
-    );
+    const hasIssuerConfig = Object.values(data.ACCESS_CODE_CONFIGS).some((c) => c.issuer);
     if (hasIssuerConfig && !data.COUNSEL_PRIVATE_KEY_PEM) {
       ctx.addIssue({
         code: "custom",

--- a/server/nodejs/src/lib/__mocks__/accessCodeConfigs.ts
+++ b/server/nodejs/src/lib/__mocks__/accessCodeConfigs.ts
@@ -7,6 +7,7 @@ export const mockAccessCodeConfigs = {
     client: "main",
     apiUrl: "https://test-api.counselhealth.com",
     userType: "main" as const,
+    apiKey: "sk_test_main01_key",
     issuer: "https://local-test-partner.example.com/main",
   },
   APIK01: {
@@ -19,30 +20,35 @@ export const mockAccessCodeConfigs = {
     client: "onboarding",
     apiUrl: "https://test-api.counselhealth.com",
     userType: "onboarding" as const,
+    apiKey: "sk_test_onbr01_key",
     issuer: "https://local-test-partner.example.com/onboarding",
   },
   CLNT02: {
     client: "client2",
     apiUrl: "https://test-api.counselhealth.com",
     userType: "main" as const,
+    apiKey: "sk_test_clnt02_key",
     issuer: "https://local-test-partner.example.com/client2",
   },
   MAIN02: {
     client: "main",
     apiUrl: "https://test-api.counselhealth.com",
     userType: "main" as const,
+    apiKey: "sk_test_main02_key",
     issuer: "https://local-test-partner.example.com/main",
   },
   ONBR02: {
     client: "onboarding",
     apiUrl: "https://local-api.counselhealth.com",
     userType: "onboarding" as const,
+    apiKey: "sk_test_onbr02_key",
     issuer: "https://local-test-partner.example.com/onboarding",
   },
   CLNT01: {
     client: "client1",
     apiUrl: "https://local.counselhealth.com",
     userType: "onboarding" as const,
+    apiKey: "sk_test_clnt01_key",
     issuer: "https://local-test-partner.example.com/client1",
   },
 } as const;

--- a/server/nodejs/src/lib/__mocks__/envConfig.ts
+++ b/server/nodejs/src/lib/__mocks__/envConfig.ts
@@ -41,18 +41,21 @@ C5BbuQIDjQMF9oegNdwn/V5/
         client: "main",
         apiUrl: "https://test-api.counselhealth.com",
         userType: "main",
+        apiKey: "sk_test_main01_key",
         issuer: "https://local-test-partner.example.com/main",
       },
       CODE23: {
         client: "main",
         apiUrl: "https://test-api.counselhealth.com",
         userType: "main",
+        apiKey: "sk_test_code23_key",
         issuer: "https://local-test-partner.example.com/main",
       },
       ONBR01: {
         client: "onboarding",
         apiUrl: "https://test-api.counselhealth.com",
         userType: "onboarding",
+        apiKey: "sk_test_onbr01_key",
         issuer: "https://local-test-partner.example.com/onboarding",
       },
       APIK01: {

--- a/server/nodejs/src/lib/counsel.ts
+++ b/server/nodejs/src/lib/counsel.ts
@@ -1,11 +1,11 @@
-import { z } from "zod";
-import { getAccessCodeConfig } from "@/envConfig";
-import { v4 as uuidv4 } from "uuid";
 import { User } from "@/db/schemas/user";
-import { parseName } from "@/lib/name";
+import { getAccessCodeConfig } from "@/envConfig";
 import { fetchWithRetry } from "@/lib/http";
-import { signCounselJwt } from "./keys";
 import { counselLogger } from "@/lib/logger";
+import { parseName } from "@/lib/name";
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+import { signCounselJwt } from "./keys";
 
 export const UserTypeSchema = z.enum(["main", "onboarding"]);
 export type UserType = z.infer<typeof UserTypeSchema>;
@@ -14,14 +14,13 @@ const getRequestUrl = (apiUrl: string, path: string) => `${apiUrl}${path}`;
 
 function getConfig(accessCode: string) {
   const config = getAccessCodeConfig(accessCode);
-  if (!config)
-    throw new Error(`No config found for access code "${accessCode}".`);
+  if (!config) throw new Error(`No config found for access code "${accessCode}".`);
   return config;
 }
 
 const getRequestHeaders = async (
   accessCode: string,
-  idempotencyKey?: string
+  idempotencyKey?: string,
 ): Promise<Record<string, string>> => {
   const config = getConfig(accessCode);
 
@@ -29,9 +28,7 @@ const getRequestHeaders = async (
   // JWT auth only: sign a JWT with issuer when apiKey is not present
   const { apiKey, issuer } = config;
   if (!apiKey && !issuer) {
-    throw new Error(
-      `Access code "${accessCode}" must have either apiKey or issuer configured`
-    );
+    throw new Error(`Access code "${accessCode}" must have either apiKey or issuer configured`);
   }
   const authToken = apiKey ? apiKey : await signCounselJwt("server", issuer!);
 
@@ -84,19 +81,16 @@ export async function getCounselUserThreads({
   accessCode: string;
 }) {
   const apiUrl = getApiUrl(accessCode);
-  const response = await fetchWithRetry(
-    getRequestUrl(apiUrl, `/v1/user/${userId}/threads`),
-    {
-      method: "GET",
-      headers: await getRequestHeaders(accessCode),
-    }
-  );
+  const response = await fetchWithRetry(getRequestUrl(apiUrl, `/v1/user/${userId}/threads`), {
+    method: "GET",
+    headers: await getRequestHeaders(accessCode),
+  });
   if (!response.ok) {
     const detail = await readHttpErrorDetail(response);
     throw new Error(
       `Request to get user threads failed: ${response.status} ${
         response.statusText
-      }${detail ? ` ${detail}` : ""}`
+      }${detail ? ` ${detail}` : ""}`,
     );
   }
   return await response.json();
@@ -113,20 +107,17 @@ export async function getCounselSignedAppUrl({
 }) {
   counselLogger.debug({ userId }, "Getting signed app url for user");
   const apiUrl = getApiUrl(accessCode);
-  const response = await fetchWithRetry(
-    getRequestUrl(apiUrl, `/v1/user/${userId}/signedAppUrl`),
-    {
-      method: "POST",
-      headers: await getRequestHeaders(accessCode),
-      body: JSON.stringify(sessionData ?? {}),
-    }
-  );
+  const response = await fetchWithRetry(getRequestUrl(apiUrl, `/v1/user/${userId}/signedAppUrl`), {
+    method: "POST",
+    headers: await getRequestHeaders(accessCode),
+    body: JSON.stringify(sessionData ?? {}),
+  });
   if (!response.ok) {
     const detail = await readHttpErrorDetail(response);
     throw new Error(
       `Request to get signed app url failed: ${response.status} ${
         response.statusText
-      }${detail ? ` ${detail}` : ""}`
+      }${detail ? ` ${detail}` : ""}`,
     );
   }
   const data = await response.json();
@@ -141,21 +132,18 @@ export async function signOutCounselUser({
   accessCode: string;
 }) {
   const apiUrl = getApiUrl(accessCode);
-  const response = await fetchWithRetry(
-    getRequestUrl(apiUrl, `/v1/user/${userId}/signOut`),
-    {
-      method: "POST",
-      headers: await getRequestHeaders(accessCode),
-      // Empty body is required by Counsel
-      body: JSON.stringify({}),
-    }
-  );
+  const response = await fetchWithRetry(getRequestUrl(apiUrl, `/v1/user/${userId}/signOut`), {
+    method: "POST",
+    headers: await getRequestHeaders(accessCode),
+    // Empty body is required by Counsel
+    body: JSON.stringify({}),
+  });
   if (!response.ok) {
     const detail = await readHttpErrorDetail(response);
     throw new Error(
       `Request to sign out user failed: ${response.status} ${response.statusText}${
         detail ? ` ${detail}` : ""
-      }`
+      }`,
     );
   }
 }
@@ -182,7 +170,7 @@ export async function createCounselUser(user: User, accessCode: string) {
     throw new Error(
       `Request to create user failed: ${response.status} ${
         response.statusText
-      }${detail ? ` ${detail}` : ""}`
+      }${detail ? ` ${detail}` : ""}`,
     );
   }
   const data = await response.json();
@@ -217,15 +205,12 @@ function convertUserToCounselUser(user: User) {
 
 export async function createCounselDraftUser(user: User, accessCode: string) {
   const apiUrl = getApiUrl(accessCode);
-  const response = await fetchWithRetry(
-    getRequestUrl(apiUrl, `/v1/user/draft`),
-    {
-      method: "POST",
-      // Use the user id as the idempotency key
-      headers: await getRequestHeaders(accessCode),
-      body: JSON.stringify(convertUserToCounselDraftUser(user)),
-    }
-  );
+  const response = await fetchWithRetry(getRequestUrl(apiUrl, `/v1/user/draft`), {
+    method: "POST",
+    // Use the user id as the idempotency key
+    headers: await getRequestHeaders(accessCode),
+    body: JSON.stringify(convertUserToCounselDraftUser(user)),
+  });
   if (!response.ok) {
     // Handle duplicate user case (this can happen on server restarts where the in-memory DB is reset)
     if (response.status === 409) {
@@ -239,7 +224,7 @@ export async function createCounselDraftUser(user: User, accessCode: string) {
     throw new Error(
       `Request to create draft user failed: ${response.status} ${
         response.statusText
-      }${detail ? ` ${detail}` : ""}`
+      }${detail ? ` ${detail}` : ""}`,
     );
   }
   const data = await response.json();

--- a/server/nodejs/src/lib/observability.ts
+++ b/server/nodejs/src/lib/observability.ts
@@ -1,6 +1,6 @@
+import { httpLogger } from "@/lib/logger";
 import { Elysia } from "elysia";
 import { v4 as uuidv4 } from "uuid";
-import { httpLogger } from "@/lib/logger";
 
 /**
  * Elysia plugin that logs all incoming requests and their responses.

--- a/server/nodejs/src/routes/token/index.ts
+++ b/server/nodejs/src/routes/token/index.ts
@@ -1,31 +1,29 @@
+import { getAccessCodeConfig } from "@/envConfig";
+import { UserFacingError } from "@/lib/http";
+import { signCounselJwt } from "@/lib/keys";
+import { withAuth } from "@/lib/user-session";
 import { Elysia } from "elysia";
 import { z } from "zod";
-import { signCounselJwt } from "@/lib/keys";
-import { UserFacingError } from "@/lib/http";
-import { withAuth } from "@/lib/user-session";
-import { getAccessCodeConfig } from "@/envConfig";
 
 const TokenResponseSchema = z.object({ token: z.string() });
 
 // Returns a short-lived Counsel JWT for the authenticated user.
 // The Next.js app uses this to call Counsel APIs directly.
-export const TokenPlugin = new Elysia({ prefix: "/token" })
-  .use(withAuth)
-  .post(
-    "/",
-    async ({ user }): Promise<{ token: string }> => {
-      const config = getAccessCodeConfig(user.accessCode);
-      if (!config) {
-        throw new UserFacingError("Invalid access code", 400);
-      }
-      if (!config.issuer) {
-        throw new UserFacingError(
-          "This access code uses API key auth. Use the server's /user/signedAppUrl endpoint instead of /token.",
-          400
-        );
-      }
-      const token = await signCounselJwt(user.userId, config.issuer);
-      return { token };
-    },
-    { response: TokenResponseSchema }
-  );
+export const TokenPlugin = new Elysia({ prefix: "/token" }).use(withAuth).post(
+  "/",
+  async ({ user }): Promise<{ token: string }> => {
+    const config = getAccessCodeConfig(user.accessCode);
+    if (!config) {
+      throw new UserFacingError("Invalid access code", 400);
+    }
+    if (!config.issuer) {
+      throw new UserFacingError(
+        "This access code uses API key auth. Use the server's /user/signedAppUrl endpoint instead of /token.",
+        400,
+      );
+    }
+    const token = await signCounselJwt(user.userId, config.issuer);
+    return { token };
+  },
+  { response: TokenResponseSchema },
+);

--- a/server/nodejs/src/routes/user/signUp/index.ts
+++ b/server/nodejs/src/routes/user/signUp/index.ts
@@ -54,7 +54,8 @@ export async function signUpHandler({
     userType,
     client,
     counselUserId: user.counsel_user_id,
-    authType: config.apiKey ? "apiKey" : "jwt",
+    // apiKey is always configured for server→Counsel; issuer selects browser-direct JWT flow.
+    authType: config.issuer ? "jwt" : "apiKey",
     navMode: config.navMode ?? "standalone",
     counselApiUrl: config.apiUrl,
   };

--- a/server/nodejs/src/routes/user/userRoutes.ts
+++ b/server/nodejs/src/routes/user/userRoutes.ts
@@ -1,13 +1,9 @@
+import { withAuth } from "@/lib/user-session";
 import { Elysia } from "elysia";
 import { z } from "zod";
-import { withAuth } from "@/lib/user-session";
-import { signUpHandler, SignUpBodySchema, SignUpResponseSchema } from "./signUp";
 import { signOutHandler } from "./signOut";
-import {
-  signedAppUrlHandler,
-  SessionDataSchema,
-  SignedAppUrlResponseSchema,
-} from "./signedAppUrl";
+import { SignUpBodySchema, signUpHandler, SignUpResponseSchema } from "./signUp";
+import { SessionDataSchema, signedAppUrlHandler, SignedAppUrlResponseSchema } from "./signedAppUrl";
 import { threadsHandler } from "./threads";
 
 export const UserPlugin = new Elysia({ prefix: "/user" })
@@ -21,9 +17,8 @@ export const UserPlugin = new Elysia({ prefix: "/user" })
   .post("/signOut", ({ user }) => signOutHandler({ user }), {
     response: z.object({ status: z.literal("ok") }),
   })
-  .post(
-    "/signedAppUrl",
-    ({ user, body }) => signedAppUrlHandler({ user, body }),
-    { body: SessionDataSchema, response: SignedAppUrlResponseSchema }
-  )
+  .post("/signedAppUrl", ({ user, body }) => signedAppUrlHandler({ user, body }), {
+    body: SessionDataSchema,
+    response: SignedAppUrlResponseSchema,
+  })
   .get("/threads", ({ user }) => threadsHandler({ user }));

--- a/web/nextjs/src/actions/handleLogin.ts
+++ b/web/nextjs/src/actions/handleLogin.ts
@@ -1,11 +1,11 @@
 "use server";
 
+import { authLogger } from "@/lib/logger";
+import { prewarmSessionJwt, signUpCounselUser } from "@/lib/server";
 import { getSession } from "@/lib/session";
 import { redirect } from "next/navigation";
-import { z } from "zod";
 import { v4 as uuidv4 } from "uuid";
-import { signUpCounselUser, prewarmSessionJwt } from "@/lib/server";
-import { authLogger } from "@/lib/logger";
+import { z } from "zod";
 
 const FormDataSchema = z.object({
   accessCode: z.string().length(6),

--- a/web/nextjs/src/actions/signOut.ts
+++ b/web/nextjs/src/actions/signOut.ts
@@ -1,10 +1,10 @@
 "use server";
 
+import { authLogger } from "@/lib/logger";
 import { getChatSignedAppUrlCacheKey, signOutCounselUser } from "@/lib/server";
 import { getSession } from "@/lib/session";
 import { revalidateTag } from "next/cache";
 import { redirect } from "next/navigation";
-import { authLogger } from "@/lib/logger";
 
 export async function signOut() {
   const session = await getSession();

--- a/web/nextjs/src/app/api/counsel/signedAppUrl/route.ts
+++ b/web/nextjs/src/app/api/counsel/signedAppUrl/route.ts
@@ -1,10 +1,10 @@
-import { getSession } from "@/lib/session";
 import { serverEnv } from "@/envConfig";
-import { getValidCounselJwt } from "@/lib/server";
 import { fetchWithRetry } from "@/lib/http";
+import { getSession } from "@/lib/session";
 
 /**
- * Proxies POST /v1/user/:id/signedAppUrl for the integrated chat client.
+ * Proxies POST /v1/user/:id/signedAppUrl for the integrated chat client via the
+ * demo server. Browser-direct JWT uses Counsel from the client, not this route.
  */
 export async function POST(req: Request) {
   const session = await getSession();
@@ -13,27 +13,6 @@ export async function POST(req: Request) {
   }
 
   const sessionData = await req.json();
-  const counselJwt = await getValidCounselJwt(session);
-
-  if (session.authType === "jwt" && counselJwt) {
-    const resp = await fetchWithRetry(
-      `${session.counselApiUrl}/v1/user/${session.counselUserId}/signedAppUrl`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${counselJwt}`,
-          "Idempotency-Key": crypto.randomUUID(),
-        },
-        body: JSON.stringify(sessionData),
-      },
-    );
-    const body = await resp.text();
-    return new Response(body, {
-      status: resp.status,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
 
   const resp = await fetchWithRetry(`${serverEnv.SERVER_HOST}/user/signedAppUrl`, {
     method: "POST",

--- a/web/nextjs/src/app/api/counsel/threads/route.ts
+++ b/web/nextjs/src/app/api/counsel/threads/route.ts
@@ -1,38 +1,15 @@
 import { getSession } from "@/lib/session";
 import { serverEnv } from "@/envConfig";
-import { getValidCounselJwt } from "@/lib/server";
 import { fetchWithRetry } from "@/lib/http";
 
 /**
- * Proxies GET /v1/user/:id/threads for the integrated chat client.
- * Uses the Counsel JWT when authType is jwt; otherwise forwards to the demo
- * server with the session token (API key flow).
+ * Proxies GET /v1/user/:id/threads for the integrated chat client via the demo
+ * server (session Bearer). Browser-direct JWT calls go to Counsel from the client.
  */
 export async function GET() {
   const session = await getSession();
   if (!session.token || !session.counselUserId) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const counselJwt = await getValidCounselJwt(session);
-
-  if (session.authType === "jwt" && counselJwt) {
-    const resp = await fetchWithRetry(
-      `${session.counselApiUrl}/v1/user/${session.counselUserId}/threads`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${counselJwt}`,
-          "Idempotency-Key": crypto.randomUUID(),
-        },
-      },
-    );
-    const body = await resp.text();
-    return new Response(body, {
-      status: resp.status,
-      headers: { "Content-Type": "application/json" },
-    });
   }
 
   const resp = await fetchWithRetry(`${serverEnv.SERVER_HOST}/user/threads`, {

--- a/web/nextjs/src/components/counsel/CounselAppClient.tsx
+++ b/web/nextjs/src/components/counsel/CounselAppClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
 import { useCounselAppMessageHandler } from "@/hooks/useCounselAppMessageHandler";
+import { useEffect, useRef } from "react";
 
 export type CounselAppClientProps = {
   signedAppUrl: string;
@@ -34,7 +34,10 @@ export default function CounselAppClient({
     }
   })();
 
-  const { switchThread } = useCounselAppMessageHandler({ iframeRef, iframeOrigin });
+  const { switchThread } = useCounselAppMessageHandler({
+    iframeRef,
+    iframeOrigin,
+  });
 
   useEffect(() => {
     if (isFirstRender.current) {

--- a/web/nextjs/src/components/integrated/ChatInput.tsx
+++ b/web/nextjs/src/components/integrated/ChatInput.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useRef, useEffect } from "react";
-import { ArrowUp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { ArrowUp } from "lucide-react";
+import { useEffect, useRef } from "react";
 
 type ChatInputProps = {
   onSend: (text: string) => void;
@@ -14,7 +14,11 @@ type ChatInputProps = {
  * Auto-expanding textarea chat input.
  * Enter to submit, Shift+Enter for newline.
  */
-export default function ChatInput({ onSend, disabled, placeholder = "Type a message…" }: ChatInputProps) {
+export default function ChatInput({
+  onSend,
+  disabled,
+  placeholder = "Type a message…",
+}: ChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Auto-focus on mount

--- a/web/nextjs/src/components/integrated/ChatList.tsx
+++ b/web/nextjs/src/components/integrated/ChatList.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo } from "react";
-import { Stethoscope, SquarePen, X, LogOut } from "lucide-react";
 import { Logo } from "@/components/logo";
-import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { ThreadItem } from "@/lib/schemas";
+import { cn } from "@/lib/utils";
+import { LogOut, SquarePen, Stethoscope, X } from "lucide-react";
+import { useCallback, useMemo } from "react";
 import type { HostThread } from "./types";
 
 function formatRelativeTime(dateStr: string): string {
@@ -20,9 +21,7 @@ function formatRelativeTime(dateStr: string): string {
   return date.toLocaleDateString();
 }
 
-type UnifiedThread =
-  | { type: "host"; thread: HostThread }
-  | { type: "counsel"; thread: ThreadItem };
+type UnifiedThread = { type: "host"; thread: HostThread } | { type: "counsel"; thread: ThreadItem };
 
 type ChatListProps = {
   hostThreads: HostThread[];
@@ -79,11 +78,16 @@ export default function ChatList({
       <div className="flex items-center justify-between px-4 h-16 shrink-0 border-b border-zinc-100 dark:border-zinc-800">
         <div className="flex items-center gap-3">
           <Logo className="size-5 text-zinc-900 dark:text-zinc-100" />
-          <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100">Embedded Demo</span>
+          <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+            Embedded Demo
+          </span>
         </div>
         <div className="flex items-center gap-1">
           <button
-            onClick={() => { onNewChat(); onClose?.(); }}
+            onClick={() => {
+              onNewChat();
+              onClose?.();
+            }}
             disabled={isPending}
             aria-label="New chat"
             className="flex items-center justify-center size-9 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-zinc-100 disabled:opacity-40 transition-colors"
@@ -105,17 +109,27 @@ export default function ChatList({
       {/* Thread list */}
       <div className="flex-1 overflow-y-auto py-2">
         {isThreadsLoading && (
-          <p className="px-4 py-3 text-sm text-zinc-400">Loading…</p>
+          <div
+            className="space-y-0 px-1"
+            role="status"
+            aria-busy="true"
+            aria-label="Loading conversations"
+          >
+            {Array.from({ length: 6 }, (_, i) => (
+              <div key={i} className="w-[calc(100%-8px)] mx-1 px-4 py-2.5 rounded-lg">
+                <Skeleton className="h-[18px] w-[min(85%,14rem)] mb-2 rounded-md animate-pulse dark:from-zinc-800 dark:to-zinc-700" />
+                <Skeleton className="h-3 w-14 rounded-md animate-pulse dark:from-zinc-800 dark:to-zinc-700" />
+              </div>
+            ))}
+          </div>
         )}
         {!isThreadsLoading && allThreads.length === 0 && (
           <p className="px-4 py-3 text-sm text-zinc-400">No conversations yet</p>
         )}
         {allThreads.map((item) => {
-          const isActive =
-            activeThreadId === item.thread.id && activeThreadType === item.type;
+          const isActive = activeThreadId === item.thread.id && activeThreadType === item.type;
           const displayName =
-            item.thread.display_name ||
-            (item.type === "counsel" ? "Counsel chat" : "New chat");
+            item.thread.display_name || (item.type === "counsel" ? "Counsel chat" : "New chat");
 
           return (
             <button

--- a/web/nextjs/src/components/integrated/ChatThread.tsx
+++ b/web/nextjs/src/components/integrated/ChatThread.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useRef, useEffect, useCallback, useState } from "react";
-import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { HostThread } from "./types";
-import MessageBubble from "./MessageBubble";
-import CounselCard from "./CounselCard";
+import { ChevronDown } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ChatInput from "./ChatInput";
+import CounselCard from "./CounselCard";
+import MessageBubble from "./MessageBubble";
+import type { HostThread } from "./types";
 
 type ChatThreadProps = {
   thread: HostThread;
@@ -28,10 +28,9 @@ export default function ChatThread({
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => setIsAtBottom(entry.isIntersecting),
-      { threshold: 0.1 },
-    );
+    const observer = new IntersectionObserver(([entry]) => setIsAtBottom(entry.isIntersecting), {
+      threshold: 0.1,
+    });
     observer.observe(sentinel);
     return () => observer.disconnect();
   }, []);

--- a/web/nextjs/src/hooks/useCounselApi.ts
+++ b/web/nextjs/src/hooks/useCounselApi.ts
@@ -35,9 +35,7 @@ type SignedUrlAction =
 
 async function fetchThreadsFromServer(config: CounselApiConfig): Promise<ThreadItem[]> {
   const direct = config.counselJwt.length > 0;
-  const url = direct
-    ? `${config.counselDirectApiBase}/threads`
-    : "/api/counsel/threads";
+  const url = direct ? `${config.counselDirectApiBase}/threads` : "/api/counsel/threads";
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "Idempotency-Key": crypto.randomUUID(),
@@ -89,7 +87,9 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
 
 function pickNewestByActivity(threads: ThreadItem[]): ThreadItem {
   return threads.reduce((best, t) =>
-    new Date(t.last_activity_time).getTime() > new Date(best.last_activity_time).getTime() ? t : best,
+    new Date(t.last_activity_time).getTime() > new Date(best.last_activity_time).getTime()
+      ? t
+      : best,
   );
 }
 

--- a/web/nextjs/src/lib/__tests__/server.test.ts
+++ b/web/nextjs/src/lib/__tests__/server.test.ts
@@ -1,12 +1,7 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "vitest";
-import { getCounselSignedAppUrl, getChatSignedAppUrlCacheKey } from "../server";
-import { SignJWT } from "jose";
+import type { IronSession } from "iron-session";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { getChatSignedAppUrlCacheKey, getCounselSignedAppUrl } from "../server";
+import type { SessionData } from "../session";
 
 const originalFetch = globalThis.fetch;
 
@@ -18,27 +13,24 @@ function getUrlString(input: RequestInfo | URL): string {
       : input.url;
 }
 
-async function makeJwt(expiresInSeconds: number): Promise<string> {
-  const secret = new TextEncoder().encode("test-secret");
-  return new SignJWT({})
-    .setProtectedHeader({ alg: "HS256" })
-    .setExpirationTime(Math.floor(Date.now() / 1000) + expiresInSeconds)
-    .sign(secret);
-}
-
 function makeSession(
-  overrides: Partial<{ authType: "apiKey" | "jwt"; counselJwt: string }> = {}
-) {
-  return {
+  overrides: Partial<SessionData> = {}
+): IronSession<SessionData> {
+  const session: SessionData = {
     token: "session-token",
-    userType: "main" as const,
+    userType: "main",
     counselUserId: "counsel-user-456",
-    authType: "apiKey" as const,
+    authType: "apiKey",
+    navMode: "standalone",
+    counselApiUrl: "https://test-api.example.com",
+    ...overrides,
+  };
+  return {
+    ...session,
     save: async () => {},
     destroy: async () => {},
     updateConfig: () => {},
-    ...overrides,
-  };
+  } as IronSession<SessionData>;
 }
 
 describe("getCounselSignedAppUrl", () => {
@@ -78,47 +70,8 @@ describe("getCounselSignedAppUrl", () => {
     expect(url).toBe("https://embed.counsel.test/signed");
   });
 
-  test("jwt flow: uses cached counselJwt if still valid (no /token call)", async () => {
-    const validJwt = await makeJwt(3600);
-    let tokenCalled = false;
-    globalThis.fetch = async (input: RequestInfo | URL) => {
-      const urlStr = getUrlString(input);
-      if (urlStr.includes("/token")) {
-        tokenCalled = true;
-        return new Response(JSON.stringify({ token: "should-not-be-called" }), {
-          status: 200,
-        });
-      }
-      if (urlStr.includes("/signedAppUrl")) {
-        return new Response(
-          JSON.stringify({ url: "https://embed.counsel.test/signed" }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }
-        );
-      }
-      return new Response("Not found", { status: 404 });
-    };
-    const url = await getCounselSignedAppUrl(
-      makeSession({ authType: "jwt", counselJwt: validJwt })
-    );
-    expect(url).toBe("https://embed.counsel.test/signed");
-    expect(tokenCalled, "should not call /token when cached JWT is valid").toBe(
-      false
-    );
-  });
-
-  test("jwt flow: fetches fresh JWT from /token when session has no counselJwt", async () => {
+  test("jwt authType: signed app url still goes via demo server", async () => {
     const url = await getCounselSignedAppUrl(makeSession({ authType: "jwt" }));
-    expect(url).toBe("https://embed.counsel.test/signed");
-  });
-
-  test("jwt flow: fetches fresh JWT from /token when cached counselJwt is expired", async () => {
-    const expiredJwt = await makeJwt(-60);
-    const url = await getCounselSignedAppUrl(
-      makeSession({ authType: "jwt", counselJwt: expiredJwt })
-    );
     expect(url).toBe("https://embed.counsel.test/signed");
   });
 

--- a/web/nextjs/src/lib/server.ts
+++ b/web/nextjs/src/lib/server.ts
@@ -87,55 +87,15 @@ export async function prewarmSessionJwt(session: IronSession<SessionData>): Prom
 /**
  * @description Get the signed app url for a user.
  *
- * Two flows depending on authType:
- * - "apiKey": proxied through the demo server (demo server calls Counsel API with API key)
- * - "jwt": calls Counsel API directly with a Counsel JWT
- *
- * JWT caching strategy for the "jwt" flow:
- * - At login, handleLogin pre-warms the JWT into session.counselJwt (saved via Server Action).
- * - On the chat page, if the cached JWT is still valid it's used directly (fast, no extra call).
- * - If the cached JWT is expired, a fresh one is fetched from /token and used in-memory only.
- * Cached in NextJS so the same URL is reused across navigations until invalidated.
+ * Always proxied through the demo server (demo server calls Counsel with the access code API key).
+ * Issuer/JWT browser-direct traffic uses session.counselJwt from {@link getValidCounselJwt}, not this helper.
  */
 export async function getCounselSignedAppUrl(
   session: IronSession<SessionData>,
   sessionData?: Record<string, unknown>,
 ) {
-  const { token, counselUserId, authType, counselJwt } = session;
+  const { token, counselUserId } = session;
 
-  if (authType === "jwt") {
-    const jwt =
-      counselJwt && isCounselJwtValid(counselJwt) ? counselJwt : await fetchCounselJwt(token);
-
-    // jwt auth flow: calls the Counsel API directly (no demo server proxy)
-    const resp = await fetchWithRetry(
-      `${session.counselApiUrl}/v1/user/${counselUserId}/signedAppUrl`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...getAuthorizationHeader(jwt),
-        },
-        body: JSON.stringify(sessionData ?? {}),
-        cache: "default",
-        next: {
-          revalidate: 3600,
-          tags: [getChatSignedAppUrlCacheKey(counselUserId)],
-        },
-      },
-    );
-    if (!resp.ok) {
-      const detail = await readHttpErrorDetail(resp);
-      throw new Error(
-        `Failed to get signed app url: ${resp.status} ${resp.statusText}${
-          detail ? ` ${detail}` : ""
-        }`,
-      );
-    }
-    return SignedAppUrlResponseSchema.parse(await resp.json()).url;
-  }
-
-  // apiKey flow: demo server proxies the request using the API key
   const resp = await fetchWithRetry(`${serverEnv.SERVER_HOST}/user/signedAppUrl`, {
     method: "POST",
     headers: {
@@ -250,7 +210,11 @@ async function fetchFromCounselServer<T>(
   if (!response.ok) {
     const detail = await readHttpErrorDetail(response);
     serverLogger.error(
-      { responseStatus: response.status, responseStatusText: response.statusText, detail },
+      {
+        responseStatus: response.status,
+        responseStatusText: response.statusText,
+        detail,
+      },
       "Failed to fetch from counsel server",
     );
     throw new Error(

--- a/web/nextjs/src/lib/session.ts
+++ b/web/nextjs/src/lib/session.ts
@@ -9,8 +9,8 @@ export interface SessionData {
   // The type of user, used to determine which user to get the signed app url for
   userType: UserType;
   counselUserId: string;
-  // "apiKey" = demo server handles Counsel API calls with an API key
-  // "jwt"    = Next.js calls Counsel API directly with a signed JWT
+  // "apiKey" = browser uses same-origin `/api/counsel/*` (demo server proxies with API key).
+  // "jwt"    = browser may call Counsel directly with a Counsel JWT (issuer configs); Not every API on Counsel is available via the JWT flow.
   authType: "apiKey" | "jwt";
   // Counsel JWT pre-warmed at login for the "jwt" flow. Used as a cache — if present and not
   // expired it avoids a /token round-trip on chat page load. Never refreshed into the session


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
- We now require an API key
- Add a simple loading state skeleton to threads list


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes environment validation and the JWT/API-key routing for Counsel requests, which can break logins or chat loading if configs or assumptions are wrong. Scope is moderate but contained to auth/config and proxy paths.
> 
> **Overview**
> **Tightens access-code configuration requirements** by making `apiKey` mandatory in `ACCESS_CODE_CONFIGS` (with `issuer` optional) and updating mocks/tests accordingly; `authType` on signup is now selected based on presence of `issuer`.
> 
> **Simplifies integrated chat networking** by removing the Next.js API routes’ and `getCounselSignedAppUrl`’s “direct Counsel JWT” path; `/api/counsel/threads` and `/api/counsel/signedAppUrl` now always proxy through the demo server, while JWT is reserved for browser-direct usage. **UI polish:** adds a skeleton loading state for the threads sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a02e31f25a59c4148b267ea8dce70f56bf7cf33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->