### PR TITLE
perf: Preload signed app url

### DIFF
--- a/automation-testing/ui/integrated-handoff.spec.ts
+++ b/automation-testing/ui/integrated-handoff.spec.ts
@@ -7,9 +7,19 @@ const accessCode =
   "AICHAT";
 
 test.describe("integrated chat - connect to care handoff", () => {
-  test("real Counsel API: signedAppUrl succeeds and Counsel iframe loads", async ({
+  test("real Counsel API: signedAppUrl preloads on page load and Counsel iframe loads after handoff", async ({
     page,
   }) => {
+    // signedAppUrl is now preloaded on page load rather than during the handoff.
+    // Set up the listener before navigation so we don't miss it.
+    const signedUrlResponsePromise = page.waitForResponse(
+      (resp: Response) =>
+        resp.url().includes("/signedAppUrl") &&
+        resp.request().method() === "POST" &&
+        resp.request().resourceType() === "fetch",
+      { timeout: 30_000 }
+    );
+
     await page.goto("/login");
     await page.getByLabel("Access Code").fill(accessCode!);
     await page.getByRole("button", { name: "Login" }).click();
@@ -21,6 +31,13 @@ test.describe("integrated chat - connect to care handoff", () => {
       await page.goto("/integrated/chat");
     }
     await page.waitForLoadState("domcontentloaded");
+
+    // Preload must succeed before the user interacts with the page.
+    const preloadResponse = await signedUrlResponsePromise;
+    expect(
+      preloadResponse.ok(),
+      `preload signedAppUrl failed: ${preloadResponse.status()}`
+    ).toBe(true);
 
     const chatInput = page.getByPlaceholder("Type a message…");
     await expect(chatInput).toBeVisible({ timeout: 10_000 });
@@ -34,32 +51,22 @@ test.describe("integrated chat - connect to care handoff", () => {
       page.getByRole("button", { name: "Connect to Counsel" })
     ).toBeVisible();
 
-    // The handoff flow now creates a thread via API first, then opens it via signedAppUrl.
-    const createThreadResponse = page.waitForResponse(
+    // During handoff only POST /threads is called — signedAppUrl is NOT
+    // re-fetched because the preloaded URL (with ?threadId= appended) is reused.
+    const createThreadResponsePromise = page.waitForResponse(
       (resp: Response) =>
         resp.url().includes("/threads") &&
-        resp.request().method() === "POST" &&
-        resp.request().resourceType() === "fetch"
-    );
-    const signedUrlResponse = page.waitForResponse(
-      (resp: Response) =>
-        resp.url().includes("/signedAppUrl") &&
         resp.request().method() === "POST" &&
         resp.request().resourceType() === "fetch"
     );
 
     await page.getByRole("button", { name: "Connect to Counsel" }).click();
 
-    const threadResponse = await createThreadResponse;
+    const threadResponse = await createThreadResponsePromise;
     expect(
       threadResponse.ok(),
       `POST /threads failed: ${threadResponse.status()}`
     ).toBe(true);
-
-    const response = await signedUrlResponse;
-    expect(response.ok(), `signedAppUrl failed: ${response.status()}`).toBe(
-      true
-    );
 
     await expect(
       page.getByRole("button", { name: /Counsel chat/ })
@@ -70,5 +77,8 @@ test.describe("integrated chat - connect to care handoff", () => {
     const src = await iframe.getAttribute("src");
     expect(src).toBeTruthy();
     expect(src).toMatch(/^https?:\/\//);
+    // The preloaded URL is reused with ?threadId= appended so the Counsel app
+    // opens directly into the new thread without a separate signedAppUrl call.
+    expect(src).toContain("threadId=");
   });
 });

--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -4,13 +4,14 @@ import { signOut } from "@/actions/signOut";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import {
   useCounselCreateThread,
+  useCounselPreloadSignedUrl,
   useCounselSignedUrl,
   useCounselThreads,
   type CounselApiConfig,
 } from "@/hooks/useCounselApi";
 import { clientLogger } from "@/lib/clientLogger";
 import { PanelLeftOpen } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import ChatList from "./integrated/ChatList";
 import ChatThread from "./integrated/ChatThread";
 import CounselChatThread from "./integrated/CounselChatThread";
@@ -102,8 +103,14 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
     addThread,
   } = useCounselThreads(counselApiConfig);
   const { getSignedUrl, isPending: isSignedUrlPending } = useCounselSignedUrl(counselApiConfig);
-  const { createThread, isPending: isCreateThreadPending } = useCounselCreateThread(counselApiConfig);
+  const { createThread, isPending: isCreateThreadPending } =
+    useCounselCreateThread(counselApiConfig);
+  const preloadedSignedUrl = useCounselPreloadSignedUrl(counselApiConfig);
   const isLoading = isSignedUrlPending || isCreateThreadPending;
+
+  // User-navigated URLs take precedence; fall back to the preloaded URL so the
+  // iframe warms in the background without any user action required.
+  const effectiveSignedUrl = counselSessionUrl ?? preloadedSignedUrl;
 
   // ---- Handlers -----------------------------------------------------------
 
@@ -120,13 +127,13 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
       if (isLoading) return;
       setActiveThread({ type: "counsel", id: threadId });
 
-      // If the iframe is already loaded, switch threads via postMessage (no reload)
-      if (counselSessionUrl) {
+      // If the iframe is already loaded (or preloaded), switch threads via postMessage (no reload)
+      if (effectiveSignedUrl) {
         setActiveCounselThreadId(threadId);
         return;
       }
 
-      // First Counsel thread click — get a signed URL with open_thread
+      // First Counsel thread click with no preloaded URL — get a signed URL with open_thread
       try {
         const url = await getSignedUrl({ action: "open_thread", thread_id: threadId });
         setCounselSessionUrl(url);
@@ -134,7 +141,7 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
         clientLogger.error({ err: error }, "Failed to load Counsel thread");
       }
     },
-    [isLoading, getSignedUrl, counselSessionUrl],
+    [isLoading, getSignedUrl, effectiveSignedUrl],
   );
 
   const handleNewChat = useCallback(() => {
@@ -211,15 +218,13 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
           agent_context: { reason_for_handoff },
         });
 
-        // 2. If the iframe is already loaded, switch to the new thread via postMessage
-        //    (no need for a new signed URL). Otherwise get one to bootstrap the iframe.
-        if (!counselSessionUrl) {
-          const url = await getSignedUrl({
-            action: "open_thread",
-            thread_id,
-          });
-          setCounselSessionUrl(url);
-        }
+        // 2. Append ?threadId to the signed URL so the Counsel app opens directly
+        //    into the new thread on load. Uses the preloaded URL as the base if
+        //    available (assets are already cached), otherwise fetches one now.
+        const base = effectiveSignedUrl ?? (await getSignedUrl(undefined));
+        const urlWithThread = new URL(base);
+        urlWithThread.searchParams.set("threadId", thread_id);
+        setCounselSessionUrl(urlWithThread.toString());
 
         // Success — now safe to remove the host thread since the counsel thread replaces it.
         setHostThreads((prev) => prev.filter((t) => t.id !== hostThreadId));
@@ -239,30 +244,34 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
         setActiveThread({ type: "host", id: hostThreadId });
       }
     },
-    [
-      isLoading,
-      createThread,
-      getSignedUrl,
-      addThread,
-      hostThreads,
-      counselSessionUrl,
-    ],
+    [isLoading, createThread, getSignedUrl, addThread, hostThreads, effectiveSignedUrl],
   );
 
   // ---- Shared sidebar props -----------------------------------------------
-
-  const chatListProps = {
-    hostThreads,
-    counselThreads,
-    activeThreadId: activeThread.id,
-    activeThreadType: activeThread.type,
-    onHostThreadClick: handleHostThreadClick,
-    onCounselThreadClick: handleCounselThreadClick,
-    onNewChat: handleNewChat,
-    onSignOut: signOut,
-    isPending: isLoading,
-    isThreadsLoading,
-  };
+  const chatListProps = useMemo(
+    () => ({
+      hostThreads,
+      counselThreads,
+      activeThreadId: activeThread.id,
+      activeThreadType: activeThread.type,
+      onHostThreadClick: handleHostThreadClick,
+      onCounselThreadClick: handleCounselThreadClick,
+      onNewChat: handleNewChat,
+      onSignOut: signOut,
+      isPending: isLoading,
+      isThreadsLoading,
+    }),
+    [
+      hostThreads,
+      counselThreads,
+      activeThread,
+      isLoading,
+      isThreadsLoading,
+      handleHostThreadClick,
+      handleCounselThreadClick,
+      handleNewChat,
+    ],
+  );
 
   // ---- Render -------------------------------------------------------------
 
@@ -317,10 +326,10 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
             </div>
           )}
 
-          {counselSessionUrl && (
+          {effectiveSignedUrl && (
             <CounselChatThread
               hidden={activeThread.type !== "counsel" || isLoading}
-              signedAppUrl={counselSessionUrl}
+              signedAppUrl={effectiveSignedUrl}
               currentThreadId={activeCounselThreadId ?? undefined}
             />
           )}

--- a/web/nextjs/src/hooks/counselQueryKeys.ts
+++ b/web/nextjs/src/hooks/counselQueryKeys.ts
@@ -1,3 +1,4 @@
 export const counselQueryKeys = {
   threads: (userId: string) => ["counsel", "threads", userId] as const,
+  preloadedSignedUrl: (userId: string) => ["counsel", "preloadedSignedUrl", userId] as const,
 };

--- a/web/nextjs/src/hooks/useCounselApi.ts
+++ b/web/nextjs/src/hooks/useCounselApi.ts
@@ -59,9 +59,7 @@ async function fetchSignedUrlFromServer(
   config: CounselApiConfig,
   action?: SignedUrlAction,
 ): Promise<string> {
-  const sessionData: Record<string, unknown> = {
-    view: { navigation: "integrated" },
-  };
+  const sessionData: Record<string, unknown> = { view: { navigation: "integrated" } };
   if (action) {
     // Counsel signedAppUrl expects a single `action` object. For create_thread,
     // initial_messages and agent_context must live on that object (not on sessionData).
@@ -115,9 +113,7 @@ async function createThreadOnServer(
   params: CreateThreadParams,
 ): Promise<CreateThreadResponse> {
   const direct = config.counselJwt.length > 0;
-  const url = direct
-    ? `${config.counselDirectApiBase}/threads`
-    : "/api/counsel/threads";
+  const url = direct ? `${config.counselDirectApiBase}/threads` : "/api/counsel/threads";
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "Idempotency-Key": crypto.randomUUID(),
@@ -197,4 +193,28 @@ export function useCounselCreateThread(config: CounselApiConfig) {
   });
 
   return { createThread: mutateAsync, isPending };
+}
+
+/**
+ * Eagerly fetches a base signed URL on mount (no action) so the Counsel iframe
+ * can be pre-warmed before the user triggers a Counsel interaction. Uses
+ * `useQuery` so the fetch is fire-and-forget — it does NOT contribute to any
+ * `isPending` flag that would disable the sidebar or show a loading state.
+ */
+export function useCounselPreloadSignedUrl(config: CounselApiConfig) {
+  const { data } = useQuery({
+    queryKey: counselQueryKeys.preloadedSignedUrl(config.counselUserId),
+    queryFn: () => fetchSignedUrlFromServer(config),
+    enabled: !!config.counselUserId,
+    // Signed URLs are valid for ~1 hour; treat as fresh for 50 min
+    staleTime: 50 * 60 * 1000,
+    // Never refetch in the background — a new URL would change effectiveSignedUrl,
+    // remounting the iframe via key={signedAppUrl} and interrupting an active session.
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    // Don't retry — a failed preload is non-blocking; the user flow will fetch when needed
+    retry: false,
+  });
+
+  return data ?? null;
 }


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
- Preloads the signed app URL and then passes the thread ID as a query param
- Needs counsel-main changes too

#### Video
https://github.com/user-attachments/assets/86831a95-5a76-4354-afdb-c8eac0721c43


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the integrated Counsel handoff flow and iframe lifecycle (preloading + URL mutation), which could affect session continuity and thread navigation if signed URLs expire or refetch unexpectedly.
> 
> **Overview**
> **Preloads the Counsel `signedAppUrl` on integrated chat page load** via a new `useCounselPreloadSignedUrl` react-query hook (cached ~50 minutes, no retries/refetch-on-focus) so the iframe can warm in the background without blocking UI.
> 
> **Updates the handoff and thread navigation flow** to reuse the preloaded signed URL: handoff now creates a thread, appends `?threadId=` to the base signed URL to open directly into the new thread, and avoids re-calling `/signedAppUrl` during handoff; existing thread clicks treat a preloaded iframe as “loaded” and switch via postMessage.
> 
> **Adjusts E2E coverage** (`integrated-handoff.spec.ts`) to assert the preload `/signedAppUrl` call happens on initial page load and that handoff only calls `POST /threads`, with the resulting iframe `src` containing `threadId=`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa766589b44ec2df06a126713e031bf9cbf70e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->