### PR TITLE
fix new thread navigation

### DIFF
--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -146,21 +146,15 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
 
   const handleNewChat = useCallback(() => {
     if (isLoading) return;
-    let targetId: string | undefined;
-    setHostThreads((prev) => {
-      const existing = prev.find((t) => t.messages.every((m) => m.role === "bot"));
-      if (existing) {
-        targetId = existing.id;
-        return prev;
-      }
-      const newThread = createNewHostThread();
-      targetId = newThread.id;
-      return [newThread, ...prev];
-    });
-    if (targetId) {
-      setActiveThread({ type: "host", id: targetId });
+    const existing = hostThreads.find((t) => t.messages.every((m) => m.role === "bot"));
+    if (existing) {
+      setActiveThread({ type: "host", id: existing.id });
+      return;
     }
-  }, [isLoading]);
+    const newThread = createNewHostThread();
+    setHostThreads((prev) => [newThread, ...prev]);
+    setActiveThread({ type: "host", id: newThread.id });
+  }, [isLoading, hostThreads]);
 
   const handleSendMessage = useCallback((threadId: string, text: string) => {
     const isTrigger = text.toLowerCase().includes(COUNSEL_TRIGGER);


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
- Easy change to ensure that clicking a new thread switches to an empty host thread always


 why was the old code failing then?
⏺ Good question — let me be precise.

  When you call setHostThreads(updaterFn), React does not call updaterFn immediately. It queues the update and calls the updater
   during the render phase, which is scheduled after the current event handler finishes. So the execution order was:

  1. setHostThreads(fn)   → update queued, fn NOT called yet
  2. if (targetId)        → still undefined, setActiveThread NEVER called
  3. handleNewChat returns
  4. [render phase] fn() runs → targetId gets set, but we're past the check

  The mutation of targetId inside the updater is a side effect that only "lands" after the function you care about has already
  completed.

  This is also why React StrictMode intentionally calls updaters twice — to surface exactly this kind of side effect and make it
   obvious the pattern is unreliable. The updater is meant to be a pure function: prev → nextState. Anything that escapes the
  updater via closure mutation is not guaranteed to be observable at a predictable time.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI state update change that only affects client-side thread creation/navigation; main risk is minor regressions if `hostThreads` is stale when clicking rapidly.
> 
> **Overview**
> Fixes "New chat" navigation in `IntegratedChatPage` by simplifying `handleNewChat`: it now checks the current `hostThreads` list for an unused bot-only thread and activates it, otherwise creates a new thread, prepends it, and immediately sets it as the active thread (removing the prior `setHostThreads` callback + external `targetId` pattern).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfcec46c316346de4a3057db590069ff03954db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->