### PR TITLE
#COU-6979(feat) - allow org's to pass phone number as null

### DIFF
--- a/server/nodejs/src/db/actions/createUser.ts
+++ b/server/nodejs/src/db/actions/createUser.ts
@@ -1,10 +1,11 @@
 import { Database } from "bun:sqlite";
 import { createCounselDraftUser, createCounselUser } from "@/lib/counsel";
+import { getAccessCodeConfig } from "@/envConfig";
 import { getDb } from "../db";
 import { UserDBSchema } from "../schemas/user";
 import { dbLogger } from "@/lib/logger";
 
-const demoUser = (id: string) => ({
+const demoUser = (id: string, includePhone: boolean) => ({
   id,
   name: "John Doe",
   email: "john.doe@example.com",
@@ -18,7 +19,7 @@ const demoUser = (id: string) => ({
       state: "CA",
       zip: "94101",
     },
-    phone: "+18007006000",
+    ...(includePhone ? { phone: "+18007006000" } : {}),
     medicalProfile: {
       conditions: ["diabetes", "hypertension"],
       medications: ["metformin", "atenolol"],
@@ -38,7 +39,9 @@ export async function createUser({
   dbProvider?: Database;
 }) {
   const db = dbProvider ?? (await getDb());
-  const newUser = demoUser(userId);
+  const config = getAccessCodeConfig(accessCode);
+  const includePhone = config?.appContextMode !== "AI";
+  const newUser = demoUser(userId, includePhone);
   // Determine if this is a draft user based on userType
   const isDraftUser = userType === "onboarding";
   const user = isDraftUser

--- a/server/nodejs/src/db/schemas/user.ts
+++ b/server/nodejs/src/db/schemas/user.ts
@@ -10,7 +10,7 @@ export const UserInfoSchema = z.object({
     state: z.string(),
     zip: z.string(),
   }),
-  phone: z.string(),
+  phone: z.string().optional(),
   medicalProfile: z.object({
     conditions: z.array(z.string()),
     medications: z.array(z.string()),

--- a/server/nodejs/src/envConfigSchema.ts
+++ b/server/nodejs/src/envConfigSchema.ts
@@ -19,6 +19,8 @@ export const AccessCodeConfigSchema = z.object({
   // Required for Browser direct calls to the Counsel API.
   // If skipped, all requests will be proxied through the demo server.
   issuer: z.url().optional(),
+  // When "AI", demo user creation omits seeded phone (matches counsel embedded AI-mode orgs).
+  appContextMode: z.enum(["AI", "Physician"]).optional(),
 });
 
 // Environment configuration schema

--- a/server/nodejs/src/lib/__tests__/counsel.test.ts
+++ b/server/nodejs/src/lib/__tests__/counsel.test.ts
@@ -236,6 +236,40 @@ describe("counsel API functions", () => {
           zip: "94101",
         },
       ]);
+      expect(body.phone).toBe("+18007006000");
+    });
+
+    test("should omit phone when user has no phone", async () => {
+      let capturedBody: unknown = null;
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockImplementation(
+            async (_: RequestInfo | URL, init?: RequestInit) => {
+              capturedBody = init?.body
+                ? JSON.parse(init.body as string)
+                : null;
+              return new Response(JSON.stringify({ id: "test-user-id" }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              });
+            }
+          )
+      );
+
+      const { createCounselUser } = await import("../counsel");
+      const userWithoutPhone = {
+        ...mockUser,
+        info: {
+          ...mockUser.info,
+          phone: undefined,
+        },
+      };
+      await createCounselUser(userWithoutPhone, "MAIN01");
+
+      const body = capturedBody as Record<string, unknown>;
+      expect(body.phone).toBeUndefined();
     });
   });
 

--- a/server/nodejs/src/lib/counsel.ts
+++ b/server/nodejs/src/lib/counsel.ts
@@ -226,7 +226,7 @@ function convertUserToCounselUser(user: User) {
     id: user.id,
     first_name: firstName,
     last_name: lastName,
-    phone: user.info.phone,
+    ...(user.info.phone !== undefined ? { phone: user.info.phone } : {}),
     dob: user.info.dob,
     email: user.email,
     sex_assigned_at_birth: user.info.sex,


### PR DESCRIPTION
Let counsel-main decide when phone number is needed



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes user schema validation and outbound payload construction, which may affect downstream Counsel API expectations and any code assuming `phone` is always present.
> 
> **Overview**
> **Phone is no longer required for users.** The `UserInfoSchema` now treats `phone` as optional, and `convertUserToCounselUser` omits the `phone` field entirely when it’s `undefined`.
> 
> **Demo user creation becomes org-context aware.** `createUser` now reads `appContextMode` from the access-code config (new optional field in `AccessCodeConfigSchema`) and skips seeding a demo phone number when the mode is `AI`. Tests were updated to assert both presence and omission of `phone` in the Counsel create-user request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52704b60372ec3585d15f78064baff97a21e8ee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->