### PR TITLE
chore: add sandbox attributes to iFrame

### DIFF
--- a/web/nextjs/src/components/IntegratedChatPage.tsx
+++ b/web/nextjs/src/components/IntegratedChatPage.tsx
@@ -9,10 +9,10 @@ import {
   useCounselThreads,
   type CounselApiConfig,
 } from "@/hooks/useCounselApi";
-import type { CounselInboundMessage } from "@/hooks/useCounselAppMessageHandler";
+import { useCounselInboundMessages } from "@/hooks/useCounselAppMessageHandler";
 import { clientLogger } from "@/lib/clientLogger";
 import { PanelLeftOpen } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import ChatList from "./integrated/ChatList";
 import ChatThread from "./integrated/ChatThread";
 import CounselChatThread from "./integrated/CounselChatThread";
@@ -112,31 +112,23 @@ export default function IntegratedChatPage({ counselApiConfig }: IntegratedChatP
   const preloadedSignedUrl = useCounselPreloadSignedUrl(counselApiConfig);
   const isLoading = isSignedUrlPending || isCreateThreadPending;
 
-  // Sync state when Counsel iframe emits thread events
-  useEffect(() => {
-    if (!counselSessionUrl) return;
-
-    let expectedOrigin: string;
+  const counselIframeOrigin = useMemo(() => {
+    if (!counselSessionUrl) return null;
     try {
-      expectedOrigin = new URL(counselSessionUrl).origin;
+      return new URL(counselSessionUrl).origin;
     } catch {
-      return;
+      return null;
     }
+  }, [counselSessionUrl]);
 
-    const handleMessage = (event: MessageEvent<CounselInboundMessage>) => {
-      if (event.origin !== expectedOrigin) return;
-
-      const data = event.data;
-      if (!data || typeof data !== "object") return;
-
-      if (data.type === "counsel:thread_created") {
+  useCounselInboundMessages({
+    iframeOrigin: counselIframeOrigin,
+    onMessage: (message) => {
+      if (message.type === "counsel:thread_created") {
         invalidateThreads();
       }
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, [counselSessionUrl, invalidateThreads]);
+    },
+  });
 
   // User-navigated URLs take precedence; fall back to the preloaded URL so the
   // iframe warms in the background without any user action required.

--- a/web/nextjs/src/components/counsel/CounselAppClient.tsx
+++ b/web/nextjs/src/components/counsel/CounselAppClient.tsx
@@ -54,8 +54,8 @@ export default function CounselAppClient({
       title="Counsel App"
       src={signedAppUrl}
       className={className}
-      // If you want to sandbox the iFrame, add:
-      // sandbox="allow-storage-access-by-user-activation allow-same-origin allow-scripts allow-forms"
+      sandbox="allow-storage-access-by-user-activation allow-same-origin allow-scripts allow-forms allow-downloads"
+      allow="clipboard-read; clipboard-write"
     />
   );
 }

--- a/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
+++ b/web/nextjs/src/hooks/useCounselAppMessageHandler.ts
@@ -1,4 +1,4 @@
-import { useCallback, type RefObject } from "react";
+import { useCallback, useEffect, useRef, type RefObject } from "react";
 
 /**
  * Outbound message types accepted by the Counsel iframe.
@@ -14,11 +14,9 @@ type CounselOutboundMessage = SwitchThreadMessage;
 /**
  * Inbound message types emitted by the Counsel iframe.
  */
-export type CounselInboundMessage =
-  | { type: "counsel:thread_created"; thread_id: string }
+export type CounselInboundMessage = { type: "counsel:thread_created"; thread_id: string };
 
-
-type Options = {
+type SendOptions = {
   iframeRef: RefObject<HTMLIFrameElement | null>;
   iframeOrigin: string | null;
 };
@@ -27,8 +25,11 @@ type Options = {
  * Returns stable send-helpers for communicating with the Counsel iframe
  * via postMessage. Add new methods here as the Counsel embedded message
  * interface expands.
+ *
+ * `iframeOrigin` is passed to `postMessage` as the `targetOrigin` argument so
+ * messages are never broadcast with `"*"`.
  */
-export function useCounselAppMessageHandler({ iframeRef, iframeOrigin }: Options) {
+export function useCounselAppMessageHandler({ iframeRef, iframeOrigin }: SendOptions) {
   const sendMessage = useCallback(
     (message: CounselOutboundMessage) => {
       if (!iframeRef.current?.contentWindow || !iframeOrigin) return;
@@ -45,4 +46,41 @@ export function useCounselAppMessageHandler({ iframeRef, iframeOrigin }: Options
   );
 
   return { switchThread };
+}
+
+type InboundOptions = {
+  /**
+   * The origin Counsel signed the URL for (e.g. `https://app.counselhealth.com`).
+   * Inbound messages from any other origin are dropped.
+   */
+  iframeOrigin: string | null;
+  onMessage: (message: CounselInboundMessage) => void;
+};
+
+/**
+ * Subscribes to `message` events from the Counsel iframe with origin validation.
+ *
+ * Any host page that renders the Counsel iframe SHOULD use this hook (or
+ * replicate the same `event.origin === iframeOrigin` check) before reading
+ * `event.data`. Without that check, any other iframe on the page can spoof
+ * Counsel events.
+ */
+export function useCounselInboundMessages({ iframeOrigin, onMessage }: InboundOptions) {
+  const onMessageRef = useRef(onMessage);
+  onMessageRef.current = onMessage;
+
+  useEffect(() => {
+    if (!iframeOrigin) return;
+
+    const handler = (event: MessageEvent) => {
+      if (event.origin !== iframeOrigin) return;
+      const data = event.data;
+      if (!data || typeof data !== "object") return;
+      if (typeof (data as { type?: unknown }).type !== "string") return;
+      onMessageRef.current(data as CounselInboundMessage);
+    };
+
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [iframeOrigin]);
 }


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
- sandbox our iFrame & create a postMessage handler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes iframe sandbox/permissions and refactors cross-window `postMessage` event handling; misconfiguration could break embedded app functionality or message-driven updates.
> 
> **Overview**
> Adds stricter iframe controls for the embedded Counsel app by enabling an explicit `sandbox` (including `allow-downloads`) and `allow` clipboard permissions on `CounselAppClient`.
> 
> Refactors Counsel iframe event handling by introducing `useCounselInboundMessages` (origin-validated `message` listener) and updating `IntegratedChatPage` to use it, computing `iframeOrigin` from the signed URL and invalidating threads on `counsel:thread_created` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0b39f05f9c0e816a5a08cdf716901c9dc1032f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->