### PR TITLE
test: Bottom sheet design

### DIFF
--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatViewUserTypeMain.swift
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatViewUserTypeMain.swift
@@ -26,9 +26,9 @@ struct ChatViewUserTypeMain: View {
                         .zIndex(1)
                         .transition(.opacity)
                 } else if let chatUrl = chatUrl {
-                    VStack {
-                        WebView(url: chatUrl, showLoadingScreen: $isLoading, onClose: onClose).ignoresSafeArea(.keyboard)
-                    }
+                    WebView(url: chatUrl, showLoadingScreen: $isLoading, onClose: onClose)
+                        .ignoresSafeArea(.keyboard)
+                        .ignoresSafeArea(edges: .bottom)
                 }
                 if isLoading && !showOnboarding {
                     // Loading screen is default state if no chat URL is available or onboarding is not shown
@@ -38,7 +38,7 @@ struct ChatViewUserTypeMain: View {
                             .progressViewStyle(CircularProgressViewStyle(tint: .blue))
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color(.systemBackground))
+                    .background(Color(red: 25.0 / 255.0, green: 25.0 / 255.0, blue: 28.0 / 255.0))
                     .zIndex(2)
                     .transition(.opacity)
                 }

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatViewUserTypeOnboarding.swift
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatViewUserTypeOnboarding.swift
@@ -19,9 +19,9 @@ struct ChatViewUserTypeOnboarding: View {
         NavigationStack {
             ZStack {
                if let chatUrl = chatUrl {
-                    VStack {
-                        WebView(url: chatUrl, showLoadingScreen: $isLoading, onClose: onClose).ignoresSafeArea(.keyboard)
-                    }
+                    WebView(url: chatUrl, showLoadingScreen: $isLoading, onClose: onClose)
+                        .ignoresSafeArea(.keyboard)
+                        .ignoresSafeArea(edges: .bottom)
                 }
                 if isLoading {
                     // Loading screen is default state if no chat URL is available or onboarding is not shown
@@ -31,7 +31,7 @@ struct ChatViewUserTypeOnboarding: View {
                             .progressViewStyle(CircularProgressViewStyle(tint: .blue))
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color(.systemBackground))
+                    .background(Color(red: 25.0 / 255.0, green: 25.0 / 255.0, blue: 28.0 / 255.0))
                     .zIndex(2)
                     .transition(.opacity)
                 }

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/WebView.swift
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/WebView.swift
@@ -13,20 +13,22 @@ struct WebView: UIViewRepresentable {
     @Binding var showLoadingScreen: Bool
     var onClose: () -> Void = {}
 
-    func makeUIView(context: Context) -> WKWebView {
+    func makeUIView(context: Context) -> UIView {
         let configuration = WKWebViewConfiguration()
         let userContentController = WKUserContentController()
 
         // Enable JavaScript to open new windows
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
 
-        // Inject viewport meta tag script to set the viewport to the device width
+        // Inject viewport meta tag script to set the viewport to the device width.
+        // `viewport-fit=cover` is required so iOS reports real `env(safe-area-inset-*)`
+        // values to CSS — without it, the page can't lay out behind the home indicator.
         let viewportScript = WKUserScript(
             source: """
                 if (!document.querySelector('meta[name="viewport"]')) {
                     var meta = document.createElement('meta');
                     meta.setAttribute('name', 'viewport');
-                    meta.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, interactive-widget=resizes-visual');
+                    meta.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, interactive-widget=resizes-visual, viewport-fit=cover');
                     document.head.appendChild(meta);
                 }
             """,
@@ -39,6 +41,10 @@ struct WebView: UIViewRepresentable {
         // web app to the native `counsel` script-message handler. The web app
         // may also call window.webkit.messageHandlers.counsel.postMessage(...)
         // directly; both paths land in the same coordinator method below.
+        //
+        // We also forward EVERY message event (filtered or not) to the native
+        // `counselDebug` handler so we can see what the Counsel page is actually
+        // emitting. Remove this once the contract is confirmed working.
         let bridgeScript = WKUserScript(
             source: """
                 console.log('[counsel-bridge] installed');
@@ -72,17 +78,54 @@ struct WebView: UIViewRepresentable {
 
         configuration.userContentController = userContentController
 
-        let webView = WKWebView(frame: .zero, configuration: configuration)
+        let webView = CounselWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
         webView.scrollView.bounces = false
+        webView.scrollView.alwaysBounceVertical = false
+        webView.scrollView.alwaysBounceHorizontal = false
+        webView.scrollView.bouncesZoom = false
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        // The Counsel web app owns its own scrolling, so the outer scroll view
+        // stays disabled to match `configureForCounselPresentation`.
+        webView.scrollView.isScrollEnabled = false
+        // Disable WKWebView's automatic safe-area content insets so the web page
+        // owns its own bottom layout via CSS env(safe-area-inset-bottom).
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
         webView.translatesAutoresizingMaskIntoConstraints = false
-        return webView
+
+        // Clear container with a `systemUltraThinMaterial` blur backdrop behind
+        // the web content, matching Counsel's presentation configuration.
+        let container = UIView()
+        container.backgroundColor = .clear
+
+        let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+        blurView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(blurView)
+        container.addSubview(webView)
+
+        NSLayoutConstraint.activate([
+            blurView.topAnchor.constraint(equalTo: container.topAnchor),
+            blurView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            blurView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            blurView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: container.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+
+        context.coordinator.webView = webView
+        return container
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {
-        let request = URLRequest(url: url)
-        uiView.load(request)
+    func updateUIView(_ uiView: UIView, context: Context) {
+        guard let webView = context.coordinator.webView else { return }
+        var request = URLRequest(url: url)
+        request.setValue("ios", forHTTPHeaderField: "x-counsel-app-os")
+        webView.load(request)
     }
 
     func makeCoordinator() -> Coordinator {
@@ -92,6 +135,7 @@ struct WebView: UIViewRepresentable {
     class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
         @Binding var showLoadingScreen: Bool
         let onClose: () -> Void
+        weak var webView: WKWebView?
 
         init(showLoadingScreen: Binding<Bool>, onClose: @escaping () -> Void) {
             _showLoadingScreen = showLoadingScreen
@@ -167,4 +211,10 @@ struct WebView: UIViewRepresentable {
             return nil
         }
     }
+}
+
+/// `WKWebView` subclass that suppresses the system keyboard accessory bar,
+/// matching `showsBuiltInInputAccessoryView = false` in Counsel's presentation.
+final class CounselWebView: WKWebView {
+    override var inputAccessoryView: UIView? { nil }
 }

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Home/HomeView.swift
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Home/HomeView.swift
@@ -23,7 +23,7 @@ struct HomeView: View {
             .padding(.horizontal)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .navigationTitle("Welcome back!")
-            .background(Color(.systemGray6).ignoresSafeArea())
+            .background(Color(red: 25.0 / 255.0, green: 25.0 / 255.0, blue: 28.0 / 255.0).ignoresSafeArea())
         }
     }
 }

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/MainTabView.swift
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/MainTabView.swift
@@ -14,18 +14,50 @@ enum TabSelection: Hashable {
 struct MainTabView: View {
     @EnvironmentObject var navigationCoordinator: NavigationCoordinator
     @AppStorage("token") private var token: String?
-    
+    @State private var showChatSheet: Bool = false
+    @State private var lastNonChatTab: TabSelection = .home
+
+    private var tabBinding: Binding<TabSelection> {
+        Binding(
+            get: { navigationCoordinator.selectedTab },
+            set: { newValue in
+                if newValue == .chat {
+                    showChatSheet = true
+                } else {
+                    lastNonChatTab = newValue
+                    navigationCoordinator.selectedTab = newValue
+                }
+            }
+        )
+    }
+
     var body: some View {
         ZStack {
-            TabView(selection: $navigationCoordinator.selectedTab) {
+            TabView(selection: tabBinding) {
                 Tab("", systemImage: "house", value: .home) {
                     HomeView(tabSelection: $navigationCoordinator.selectedTab)
                 }
                 Tab("", systemImage: "bubble", value: .chat) {
-                    ChatView()
+                    Color.clear
                 }
                 Tab("", systemImage: "person", value: .account) {
                     AccountView(presentAccessCodeModal: $navigationCoordinator.presentAccessCodeModal, tabSelection: $navigationCoordinator.selectedTab)
+                }
+            }
+            .sheet(isPresented: $showChatSheet) {
+                navigationCoordinator.selectedTab = lastNonChatTab
+            } content: {
+                ChatView()
+                    .presentationDetents([.large])
+                    .presentationBackground(Color(red: 34.0 / 255.0, green: 34.0 / 255.0, blue: 34.0 / 255.0))
+                    .ignoresSafeArea(edges: .bottom)
+            }
+            .onChange(of: navigationCoordinator.selectedTab) { _, newValue in
+                if newValue == .chat {
+                    showChatSheet = true
+                    navigationCoordinator.selectedTab = lastNonChatTab
+                } else {
+                    lastNonChatTab = newValue
                 }
             }
 


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->

#### Notes & Questions for Reviewer
<!-- Highlight anything noteworthy that the reviewer should pay
extra attention to. -->

#### Relevant Screenshots (if any)
<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-app UI and WebView presentation only; no auth or data-path changes, though debug message logging should be removed before production.
> 
> **Overview**
> Presents **chat in a large bottom sheet** instead of a full tab: the chat tab opens a sheet and keeps the previously selected tab highlighted, with dark sheet chrome and bottom safe-area ignored.
> 
> **WebView** is reworked to match Counsel’s embedded presentation: `viewport-fit=cover`, no automatic scroll/safe-area insets (CSS owns layout), blur backdrop, transparent `CounselWebView` without the keyboard accessory bar, and an `x-counsel-app-os: ios` header on loads. Temporary **`counselDebug`** logging forwards all `postMessage` traffic for contract verification.
> 
> Chat loading and **home** backgrounds switch from system colors to a fixed dark gray (`25,25,28`). Chat subviews drop the extra `VStack` wrapper and ignore the bottom safe area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcda487a3aa1d87a5f204051de6f78c974423fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->