### PR TITLE
ios keyboard pan behavior on Android

### DIFF
--- a/mobile/android/EmbeddedCounselDemo/README.md
+++ b/mobile/android/EmbeddedCounselDemo/README.md
@@ -23,8 +23,11 @@ Open in Android Studio (Hedgehog or newer): "Open" this directory.
 
 ## Running locally against the Node server
 
-The debug variant points at `http://10.0.2.2:4003`, which maps to your host
-machine's `localhost` from the Android emulator. Start the local Node server first:
+The debug variant points at `http://localhost:4003` and reaches the host Node server
+through an `adb reverse` tunnel (see below). We use the tunnel instead of the emulator's
+`10.0.2.2` host alias because a host VPN (common on work machines — look for `utun*`
+interfaces) breaks the emulator's `10.0.2.2` NAT route, while the tunnel keeps working.
+Start the local Node server first:
 
 ```bash
 cd ../../..
@@ -33,13 +36,51 @@ cd ../../..
 
 Then Run the `app` configuration in Android Studio (or `./gradlew installDebug`).
 
-`network_security_config.xml` permits cleartext only for `10.0.2.2` and `localhost`
-in the debug build. Release builds connect to the production Cloud Run URL over HTTPS.
+`network_security_config.xml` permits cleartext only for `localhost`, `127.0.0.1`, and
+`10.0.2.2` in the debug build. Release builds connect to the production Cloud Run URL over HTTPS.
 
-NOTE: you need to run these commands to allow the Android emulator to connect to the local server & web app:
+### Letting the emulator reach your host (`adb reverse`)
+
+Both the Node server (`:4003`) and the signed web-app URL the server returns
+(`http://localhost:<port>`) are reached over `localhost` from inside the emulator — but
+`localhost` inside the emulator means the emulator itself, not your Mac. Without
+forwarding, API calls fail with `error=Network` and the WebView fails with
+`net::ERR_CONNECTION_REFUSED` (logcat `pageError code=-6`). `adb reverse` tunnels the
+emulator's `localhost:<port>` back to the same port on your host:
 
 ```bash
-adb reverse tcp:3000 tcp:3000
+adb reverse tcp:4003 tcp:4003   # Node API server (BASE_URL)
+adb reverse tcp:3000 tcp:3000   # Counsel web app (signed app URL); add any other port it uses
+```
+
+This is per-session adb state — it's cleared whenever the emulator reboots/cold-boots or
+the adb server restarts, so re-run both if the app stops connecting. List active rules
+with `adb reverse --list`.
+
+#### If `adb` isn't installed yet
+
+`adb` ships with the **Android SDK Platform-Tools**. If you have Android Studio it's
+already on disk (macOS default: `~/Library/Android/sdk/platform-tools/adb`); you just
+need it on your `PATH`:
+
+```bash
+# zsh: add platform-tools to PATH permanently
+echo 'export PATH="$HOME/Library/Android/sdk/platform-tools:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+No Android Studio? Install the standalone tools:
+
+```bash
+brew install --cask android-platform-tools
+```
+
+Verify it's working and the emulator is attached (start the emulator from Android
+Studio's Device Manager first):
+
+```bash
+adb version            # confirms adb is on PATH
+adb devices            # should list e.g. "emulator-5554   device"
 ```
 
 ## Flow

--- a/mobile/android/EmbeddedCounselDemo/app/build.gradle.kts
+++ b/mobile/android/EmbeddedCounselDemo/app/build.gradle.kts
@@ -26,10 +26,14 @@ android {
 
     buildTypes {
         debug {
+            // Reach the host Node server over the adb-reverse tunnel (`adb reverse
+            // tcp:4003 tcp:4003`) rather than the emulator's 10.0.2.2 host alias. A host
+            // VPN (utun* interfaces) breaks the emulator's 10.0.2.2 NAT route, so the
+            // tunnel — same mechanism the WebView uses for localhost:3000 — is reliable.
             buildConfigField(
                 "String",
                 "BASE_URL",
-                "\"http://10.0.2.2:4003\""
+                "\"http://localhost:4003\""
             )
         }
         release {

--- a/mobile/android/EmbeddedCounselDemo/app/src/main/java/health/counsel/embeddeddemo/EmbeddedCounselDemoApp.kt
+++ b/mobile/android/EmbeddedCounselDemo/app/src/main/java/health/counsel/embeddeddemo/EmbeddedCounselDemoApp.kt
@@ -47,20 +47,24 @@ fun EmbeddedCounselDemoApp(
     val scope = rememberCoroutineScope()
 
     EmbeddedCounselDemoTheme {
-        Surface(
-            modifier = Modifier
-                .fillMaxSize()
-                .windowInsetsPadding(WindowInsets.safeDrawing),
-        ) {
+        // No safeDrawing padding on the Surface itself: the WebView is meant to render
+        // edge-to-edge (under the status/nav bars), matching iOS and relying on the web
+        // app's CSS env(safe-area-inset-*) — enabled via viewport-fit=cover in WebViewScreen.
+        // The native screens (access-code form, loading spinner) opt back into safe-area
+        // insets individually so their controls stay clear of the system bars.
+        Surface(modifier = Modifier.fillMaxSize()) {
             when (val s = authState) {
                 AuthState.Unloaded -> Box(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .windowInsetsPadding(WindowInsets.safeDrawing),
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
                 }
 
                 AuthState.SignedOut -> AccessCodeScreen(
+                    modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
                     onLogin = { code -> api.fetchToken(code) },
                     onAuthenticated = { resp ->
                         // Preload the signed URL BEFORE persisting the token. Saving the

--- a/mobile/android/EmbeddedCounselDemo/app/src/main/java/health/counsel/embeddeddemo/MainActivity.kt
+++ b/mobile/android/EmbeddedCounselDemo/app/src/main/java/health/counsel/embeddeddemo/MainActivity.kt
@@ -12,11 +12,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        // ADJUST_RESIZE is what makes the IME report as a window inset so Compose's
-        // WindowInsets.ime / imePadding() can shrink the WebView when the keyboard opens.
-        // Under edge-to-edge (decorFitsSystemWindows=false) the window itself isn't resized,
-        // so we drive the resize from Compose insets — mirroring how iOS resizes the
-        // visual viewport on keyboard events.
+        // ADJUST_RESIZE is what makes the IME report (and animate) as a WindowInsets.ime inset
+        // that Compose can read. Under edge-to-edge (decorFitsSystemWindows=false) the window
+        // itself is never resized or panned by the system, so WebViewScreen consumes that inset
+        // to pan the WebView up by the keyboard height when the keyboard opens.
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         val api = Api()
         val tokenStore = TokenStore(applicationContext)

--- a/mobile/android/EmbeddedCounselDemo/app/src/main/java/health/counsel/embeddeddemo/ui/WebViewScreen.kt
+++ b/mobile/android/EmbeddedCounselDemo/app/src/main/java/health/counsel/embeddeddemo/ui/WebViewScreen.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
+import android.view.MotionEvent
 import android.view.ViewGroup
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
@@ -61,7 +62,7 @@ private const val VIEWPORT_SCRIPT = """
         if (!document.querySelector('meta[name="viewport"]')) {
             var meta = document.createElement('meta');
             meta.setAttribute('name', 'viewport');
-            meta.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, interactive-widget=resizes-visual');
+            meta.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, interactive-widget=resizes-visual, viewport-fit=cover');
             document.head.appendChild(meta);
         }
     })();
@@ -192,6 +193,7 @@ fun WebViewScreen(
                     fetchReason = "retry"
                     attempt++
                 },
+                onSignOut = onLogout,
                 modifier = Modifier.fillMaxSize().padding(32.dp),
             )
         }
@@ -199,7 +201,12 @@ fun WebViewScreen(
 }
 
 @Composable
-private fun ErrorRetry(error: ApiError, onRetry: () -> Unit, modifier: Modifier = Modifier) {
+private fun ErrorRetry(
+    error: ApiError,
+    onRetry: () -> Unit,
+    onSignOut: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val message = when (error) {
         is ApiError.Network, is ApiError.WebViewLoad -> stringResource(R.string.error_network)
         is ApiError.Server -> stringResource(R.string.error_server)
@@ -220,10 +227,12 @@ private fun ErrorRetry(error: ApiError, onRetry: () -> Unit, modifier: Modifier 
         }
         Spacer(Modifier.height(16.dp))
         Button(onClick = onRetry) { Text(stringResource(R.string.retry)) }
+        Spacer(Modifier.height(8.dp))
+        TextButton(onClick = onSignOut) { Text(stringResource(R.string.logout_confirm)) }
     }
 }
 
-@SuppressLint("SetJavaScriptEnabled")
+@SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
 @Composable
 private fun EmbeddedWebView(
     url: String,
@@ -256,9 +265,10 @@ private fun EmbeddedWebView(
         )
     }
 
-    // imePadding() shrinks the WebView by the keyboard height when the IME opens (paired with
-    // ADJUST_RESIZE set in MainActivity). The WebView resizes its document viewport from its
-    // View bounds, so the focused input stays visible — matching iOS's resizes-visual behavior.
+    // Standard edge-to-edge keyboard handling: imePadding() shrinks the WebView to sit above
+    // the keyboard when the IME opens (paired with ADJUST_RESIZE in MainActivity, which makes
+    // the IME report as a WindowInsets.ime inset). The WebView sizes its document viewport from
+    // its View bounds, so the focused input stays visible.
     Box(modifier = modifier.imePadding()) {
         AndroidView(
             factory = { ctx ->

--- a/server/nodejs/src/index.ts
+++ b/server/nodejs/src/index.ts
@@ -5,7 +5,12 @@ import { serverLogger } from "@/lib/logger";
 
 loadEnvConfig();
 
-app.listen(env.PORT, () => {
+// Bind 0.0.0.0 (all IPv4) explicitly. Bun's default bind is the IPv6 wildcard `::`,
+// which is dual-stack on Linux (so Cloud Run is unaffected) but IPv6-only on macOS —
+// there it refuses the IPv4 connection the Android emulator makes via 10.0.2.2, so the
+// app gets "Network" / connection-refused even though `curl localhost` works. 0.0.0.0
+// is also the conventional bind for Cloud Run, so this is correct in every environment.
+app.listen({ port: env.PORT, hostname: "0.0.0.0" }, (server) => {
   // Seed the in-memory database
   getDb()
     .then(() => {
@@ -16,5 +21,17 @@ app.listen(env.PORT, () => {
       process.exit(1);
     });
 
-  serverLogger.info({ port: env.PORT }, `Server is running on http://localhost:${env.PORT}`);
+  // Log the address/family we actually bound to, not just the configured port. An
+  // IPv6-only bind (or a stale process holding IPv4) is invisible from the port number
+  // alone but is exactly what makes a client — e.g. the Android emulator's 10.0.2.2,
+  // which is IPv4-only — fail to reach the server. See server.hostname for the family.
+  serverLogger.info(
+    {
+      host: server?.hostname,
+      port: server?.port ?? env.PORT,
+      url: server?.url?.href,
+      nodeEnv: process.env.NODE_ENV ?? "undefined",
+    },
+    `Server is running on ${server?.url?.href ?? `http://localhost:${env.PORT}`}`,
+  );
 });

--- a/server/nodejs/src/lib/logger.ts
+++ b/server/nodejs/src/lib/logger.ts
@@ -16,6 +16,20 @@ export const logger = pino(
   {
     name: "server",
     level: process.env.NODE_ENV === "development" ? "debug" : "info",
+    // Keep access codes and bearer tokens out of the logs. These show up in request
+    // bodies (signUp) and headers (signedAppUrl); pino redacts them wherever they land.
+    redact: {
+      paths: [
+        "accessCode",
+        "body.accessCode",
+        "*.accessCode",
+        "headers.authorization",
+        "headers.accessCode",
+        "*.headers.authorization",
+        "*.headers.accessCode",
+      ],
+      censor: "[redacted]",
+    },
   },
   prettyStream,
 );


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->

#### Notes & Questions for Reviewer
<!-- Highlight anything noteworthy that the reviewer should pay
extra attention to. -->

#### Relevant Screenshots (if any)
<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Server listen hostname affects all environments (intended for Cloud Run/local IPv4); Android changes are demo-scoped but alter default dev networking and embedded WebView layout/keyboard behavior.
> 
> **Overview**
> Improves **local Android emulator** connectivity and **WebView UX** to align with iOS, plus small **Node server** hardening for dev.
> 
> **Android EmbeddedCounselDemo** switches the debug API base from `10.0.2.2:4003` to **`http://localhost:4003`** and documents **`adb reverse`** for both the Node API (`4003`) and the signed web app (`3000`), including VPN/`utun` pitfalls and platform-tools setup. The root Compose **Surface** no longer applies safe-area padding globally so the **WebView renders edge-to-edge**; loading and access-code screens opt back in. **WebView** injects **`viewport-fit=cover`**, keeps **IME `imePadding()`** with **`ADJUST_RESIZE`**, and adds **sign out** on URL/WebView error retry.
> 
> **Node server** explicitly listens on **`0.0.0.0`** (fixes macOS Bun IPv6-only bind blocking emulator IPv4) and logs the bound **host/port/url**. **Pino** now **redacts** `accessCode` and `Authorization` / access-code headers in logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a2f2bb5a9bf4bdf68726aac198f47824e85279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->