### PR TITLE
dev ops improvements: iOS setup + handlers for events

### DIFF
--- a/mobile/ios/EmbeddedCounselDemo/Config/Debug.xcconfig
+++ b/mobile/ios/EmbeddedCounselDemo/Config/Debug.xcconfig
@@ -1,0 +1,4 @@
+// Local development — points the app at your locally running embedded-demo server.
+// xcconfig treats // as a comment, so we build the slashes from a single-slash variable.
+SLASH = /
+BASE_URL = http:$(SLASH)$(SLASH)localhost:4003

--- a/mobile/ios/EmbeddedCounselDemo/Config/Release.xcconfig
+++ b/mobile/ios/EmbeddedCounselDemo/Config/Release.xcconfig
@@ -1,0 +1,4 @@
+// Remote/production — points the app at the deployed embedded-demo server on Cloud Run.
+// xcconfig treats // as a comment, so we build the slashes from a single-slash variable.
+SLASH = /
+BASE_URL = https:$(SLASH)$(SLASH)embedded-demo-nodejs-server-2l27waanva-ue.a.run.app

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo.xcodeproj/project.pbxproj
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXFileReference section */
 		EC4B2CD12DC4131700DBF1C1 /* EmbeddedCounselDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EmbeddedCounselDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC4B2CE42DC4131900DBF1C1 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		EC4B2CE52DC4131900DBF1C1 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -45,9 +47,19 @@
 		EC4B2CC82DC4131700DBF1C1 = {
 			isa = PBXGroup;
 			children = (
+				EC4B2CE32DC4131900DBF1C1 /* Config */,
 				EC4B2CD32DC4131700DBF1C1 /* EmbeddedCounselDemo */,
 				EC4B2CD22DC4131700DBF1C1 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		EC4B2CE32DC4131900DBF1C1 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				EC4B2CE42DC4131900DBF1C1 /* Debug.xcconfig */,
+				EC4B2CE52DC4131900DBF1C1 /* Release.xcconfig */,
+			);
+			path = Config;
 			sourceTree = "<group>";
 		};
 		EC4B2CD22DC4131700DBF1C1 /* Products */ = {
@@ -140,6 +152,7 @@
 /* Begin XCBuildConfiguration section */
 		EC4B2CDE2DC4131900DBF1C1 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EC4B2CE42DC4131900DBF1C1 /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -201,6 +214,7 @@
 		};
 		EC4B2CDF2DC4131900DBF1C1 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EC4B2CE52DC4131900DBF1C1 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatView.swift
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatView.swift
@@ -9,19 +9,20 @@ import SwiftUI
 
 struct ChatView: View {
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.dismiss) private var dismiss
     @State private var chatUrl: URL?
     @State private var showErrorModal = false
     @State private var isLoading = false
     @AppStorage("token") private var token: String?
     @AppStorage("userType") private var userType: UserType?
 
-    
+
     var body: some View {
         NavigationStack {
             if userType == .onboarding {
-                ChatViewUserTypeOnboarding(chatUrl: chatUrl, isLoading: $isLoading)
+                ChatViewUserTypeOnboarding(chatUrl: chatUrl, isLoading: $isLoading, onClose: { dismiss() })
             } else {
-                ChatViewUserTypeMain(chatUrl: chatUrl, isLoading: $isLoading)
+                ChatViewUserTypeMain(chatUrl: chatUrl, isLoading: $isLoading, onClose: { dismiss() })
             }
         }
         .task {

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatViewUserTypeMain.swift
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatViewUserTypeMain.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct ChatViewUserTypeMain: View {
     let chatUrl: URL?
     @Binding var isLoading: Bool
+    var onClose: () -> Void = {}
     @State private var showOnboarding: Bool = true
 
     
@@ -26,7 +27,7 @@ struct ChatViewUserTypeMain: View {
                         .transition(.opacity)
                 } else if let chatUrl = chatUrl {
                     VStack {
-                        WebView(url: chatUrl, showLoadingScreen: $isLoading).ignoresSafeArea(.keyboard)
+                        WebView(url: chatUrl, showLoadingScreen: $isLoading, onClose: onClose).ignoresSafeArea(.keyboard)
                     }
                 }
                 if isLoading && !showOnboarding {

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatViewUserTypeOnboarding.swift
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/ChatViewUserTypeOnboarding.swift
@@ -12,14 +12,15 @@ import SwiftUI
 struct ChatViewUserTypeOnboarding: View {
     let chatUrl: URL?
     @Binding var isLoading: Bool
+    var onClose: () -> Void = {}
 
-    
+
     var body: some View {
         NavigationStack {
             ZStack {
                if let chatUrl = chatUrl {
                     VStack {
-                        WebView(url: chatUrl, showLoadingScreen: $isLoading).ignoresSafeArea(.keyboard)
+                        WebView(url: chatUrl, showLoadingScreen: $isLoading, onClose: onClose).ignoresSafeArea(.keyboard)
                     }
                 }
                 if isLoading {

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/WebView.swift
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Chat/WebView.swift
@@ -11,14 +11,15 @@ import SwiftUI
 struct WebView: UIViewRepresentable {
     let url: URL
     @Binding var showLoadingScreen: Bool
-    
+    var onClose: () -> Void = {}
+
     func makeUIView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         let userContentController = WKUserContentController()
 
         // Enable JavaScript to open new windows
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
-        
+
         // Inject viewport meta tag script to set the viewport to the device width
         let viewportScript = WKUserScript(
             source: """
@@ -32,10 +33,45 @@ struct WebView: UIViewRepresentable {
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )
-        
         userContentController.addUserScript(viewportScript)
+
+        // Bridge `window.postMessage({ type: "counsel:..." })` from the Counsel
+        // web app to the native `counsel` script-message handler. The web app
+        // may also call window.webkit.messageHandlers.counsel.postMessage(...)
+        // directly; both paths land in the same coordinator method below.
+        let bridgeScript = WKUserScript(
+            source: """
+                console.log('[counsel-bridge] installed');
+                window.addEventListener('message', function(event) {
+                    try {
+                        var serialized;
+                        try { serialized = JSON.stringify(event.data); } catch (e) { serialized = String(event.data); }
+                        console.log('[counsel-bridge] received message', event.origin, serialized);
+                        if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.counselDebug) {
+                            window.webkit.messageHandlers.counselDebug.postMessage({ origin: event.origin, data: serialized });
+                        }
+                    } catch (e) {
+                        console.log('[counsel-bridge] debug forward failed', e);
+                    }
+
+                    var data = event.data;
+                    if (!data || typeof data !== 'object') return;
+                    if (typeof data.type !== 'string') return;
+                    if (data.type.indexOf('counsel:') !== 0) return;
+                    if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.counsel) {
+                        window.webkit.messageHandlers.counsel.postMessage(JSON.stringify(data));
+                    }
+                });
+            """,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        userContentController.addUserScript(bridgeScript)
+        userContentController.add(context.coordinator, name: "counsel")
+        userContentController.add(context.coordinator, name: "counselDebug")
+
         configuration.userContentController = userContentController
-        
+
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
@@ -43,36 +79,68 @@ struct WebView: UIViewRepresentable {
         webView.translatesAutoresizingMaskIntoConstraints = false
         return webView
     }
-    
+
     func updateUIView(_ uiView: WKWebView, context: Context) {
         let request = URLRequest(url: url)
         uiView.load(request)
     }
-    
+
     func makeCoordinator() -> Coordinator {
-        Coordinator(showLoadingScreen: $showLoadingScreen)
+        Coordinator(showLoadingScreen: $showLoadingScreen, onClose: onClose)
     }
-    
-    class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
+
+    class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
         @Binding var showLoadingScreen: Bool
-        
-        init(showLoadingScreen: Binding<Bool>) {
+        let onClose: () -> Void
+
+        init(showLoadingScreen: Binding<Bool>, onClose: @escaping () -> Void) {
             _showLoadingScreen = showLoadingScreen
+            self.onClose = onClose
         }
 
-        // Hide loading screen when the web view finishes loading
+        // Handle counsel:* events forwarded from the embedded Counsel web app.
+        // The Counsel web app posts a JSON-encoded string; we parse it here.
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            if message.name == "counselDebug" {
+                print("[counsel-bridge] saw message: \(message.body)")
+                return
+            }
+
+            guard message.name == "counsel",
+                  let json = message.body as? String,
+                  let data = json.data(using: .utf8),
+                  let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let type = body["type"] as? String else {
+                print("[counsel] unrecognized message body: \(message.body)")
+                return
+            }
+
+            print("[counsel] event: \(type) body=\(body)")
+            switch type {
+            case "counsel:ready":
+                showLoadingScreen = false
+            case "counsel:close":
+                onClose()
+            default:
+                print("[counsel] unhandled event: \(type)")
+            }
+        }
+
+        // Fallback: if counsel:ready never fires (e.g. the web app hasn't shipped
+        // that event yet), still hide the loading screen once the document loads.
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            print("[counsel] WKWebView didFinish navigation — hiding loading screen as fallback")
             showLoadingScreen = false
         }
-        
+
         private func openInExternalBrowser(_ url: URL) {
             print("Opening URL in external browser: \(url)")
-            
+
             UIApplication.shared.open(url, options: [:]) { success in
                 print("External browser open success: \(success)")
             }
         }
-        
+
         // Handle target="_blank" links
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
             print("decidePolicyFor called with URL: \(navigationAction.request.url)")
@@ -84,10 +152,10 @@ struct WebView: UIViewRepresentable {
                 decisionHandler(.cancel)
                 return
             }
-            
+
             decisionHandler(.allow)
         }
-        
+
         // Handle window.open() calls
         func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
             print("createWebView called with URL: \(navigationAction.request.url)")

--- a/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Info.plist
+++ b/mobile/ios/EmbeddedCounselDemo/EmbeddedCounselDemo/Info.plist
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- baseUrl is supplied by the active xcconfig: Config/Debug.xcconfig (local) or Config/Release.xcconfig (remote). -->
 <plist version="1.0">
-<!-- Change this to the http://localhost:4003 if running locally and you want to test against the local server -->
 <dict>
 	<key>baseUrl</key>
-	<string>https://embedded-demo-nodejs-server-2l27waanva-ue.a.run.app</string>
+	<string>$(BASE_URL)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>This app needs access to the camera to take photos for medical interactions with Counsel Physicians.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
#### Overview & Test Plan
<!-- Describe the changes made in this PR & how you tested them -->
- Adds a profile for testing
- Adds webview bridge logs


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only iOS changes: build-time URL switching and a narrow web-to-native message bridge; local networking ATS is limited to local networking, not broad cleartext.
> 
> **Overview**
> **EmbeddedCounselDemo** now picks the embedded-demo API host from build configuration instead of a hardcoded `Info.plist` URL: **Debug** uses `http://localhost:4003`, **Release** uses the Cloud Run host, via new `Config/Debug.xcconfig` and `Release.xcconfig` wired into the Xcode project. `Info.plist` reads `baseUrl` from `$(BASE_URL)` and enables **local HTTP** with `NSAllowsLocalNetworking`.
> 
> The chat **WKWebView** gains a JS bridge that forwards `window.postMessage` payloads with `counsel:*` types to native handlers (with optional `counselDebug` logging). Native code handles **`counsel:ready`** (hide loading spinner) and **`counsel:close`** (dismiss chat via SwiftUI `dismiss`), with **`didFinish` navigation** as a fallback if `counsel:ready` never fires. `onClose` is threaded from `ChatView` through the user-type chat views into `WebView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 218e72fd30bad0a831f2581f269bcbb4c4f7d49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->