### PR TITLE
internal(ci): align CI with counsel-main versions, caching, and runner sizes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,21 +17,21 @@ concurrency:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: mobile/android/EmbeddedCounselDemo
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@v6.3.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload detekt report
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: detekt-report
           path: mobile/android/EmbeddedCounselDemo/app/build/reports/detekt/
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload debug APK
         if: success()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: app-debug
           path: mobile/android/EmbeddedCounselDemo/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,12 +17,12 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: mobile/android/EmbeddedCounselDemo
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/cd-nextjs-web.yml
+++ b/.github/workflows/cd-nextjs-web.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./web/nextjs
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Instructions: https://github.com/google-github-actions/auth?tab=readme-ov-file#direct-wif
       - name: Google Auth

--- a/.github/workflows/cd-nextjs-web.yml
+++ b/.github/workflows/cd-nextjs-web.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./web/nextjs
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       # Instructions: https://github.com/google-github-actions/auth?tab=readme-ov-file#direct-wif
       - name: Google Auth
@@ -46,7 +46,7 @@ jobs:
           token_format: "access_token"
 
       - name: Login to Google Artifact Registry (GAR)
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.6.0
         with:
           registry: ${{ env.REGION }}-docker.pkg.dev
           username: _json_key

--- a/.github/workflows/cd-nodejs-server.yml
+++ b/.github/workflows/cd-nodejs-server.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./server/nodejs
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       # Instructions: https://github.com/google-github-actions/auth?tab=readme-ov-file#direct-wif
       - name: Google Auth
@@ -46,7 +46,7 @@ jobs:
           token_format: "access_token"
 
       - name: Login to Google Artifact Registry (GAR)
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.6.0
         with:
           registry: ${{ env.REGION }}-docker.pkg.dev
           username: _json_key

--- a/.github/workflows/cd-nodejs-server.yml
+++ b/.github/workflows/cd-nodejs-server.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./server/nodejs
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Instructions: https://github.com/google-github-actions/auth?tab=readme-ov-file#direct-wif
       - name: Google Auth

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -17,12 +17,12 @@ concurrency:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: 1.3.11
       - name: Lint, format, typecheck (automation-testing)
@@ -34,16 +34,17 @@ jobs:
           bun run typecheck
   e2e:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: 1.3.11
 
       - name: Mount automation-testing node_modules (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@v1.4.0
         with:
           key: ${{ runner.os }}-counsel-studio-e2e-bun-${{ hashFiles('automation-testing/bun.lock') }}
           path: automation-testing/node_modules
@@ -53,7 +54,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Fetch secrets from Doppler
-        uses: dopplerhq/secrets-fetch-action@v1.3.1
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
         with:
           doppler-token: ${{ secrets.DOPPLER_CI_TOKEN }}
           doppler-project: ${{ vars.DOPPLER_PROJECT }}
@@ -79,11 +80,14 @@ jobs:
           exit 1
 
       - name: Mount Playwright browsers cache (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@v1.4.0
         with:
           key: ${{ runner.os }}-counsel-studio-e2e-playwright-${{ hashFiles('automation-testing/package.json', 'automation-testing/bun.lock') }}
           path: ~/.cache/ms-playwright
 
+      # No --with-deps: blacksmith-4vcpu-ubuntu-2404 is based on GitHub's
+      # ubuntu-24.04 runner image, which ships Playwright's system libs
+      # pre-installed. Skipping apt-get avoids ~40s on every run.
       - name: Install Playwright Chromium
         working-directory: ./automation-testing
         run: bun run playwright:install:ci
@@ -98,27 +102,11 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: playwright-report
           path: automation-testing/reports/html
           if-no-files-found: ignore
 
-  # delete-key values must match stickydisk@v1 key in the e2e job above
-  clean-up:
-    name: Clean-up
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [e2e]
-    if: always()
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Delete sticky disk for automation-testing node_modules
-        uses: useblacksmith/stickydisk-delete@v1
-        with:
-          delete-key: ${{ runner.os }}-counsel-studio-e2e-bun-${{ hashFiles('automation-testing/bun.lock') }}
-
-      - name: Delete sticky disk for Playwright browsers
-        uses: useblacksmith/stickydisk-delete@v1
-        with:
-          delete-key: ${{ runner.os }}-counsel-studio-e2e-playwright-${{ hashFiles('automation-testing/package.json', 'automation-testing/bun.lock') }}
+# Sticky disks are not deleted here. A per-run delete destroys the cache that the
+# run populated. Run the Purge CI Caches workflow to clear them by hand.

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -35,7 +35,7 @@ jobs:
   e2e:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: automation-testing/reports/html
@@ -111,7 +111,7 @@ jobs:
     needs: [e2e]
     if: always()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Delete sticky disk for automation-testing node_modules
         uses: useblacksmith/stickydisk-delete@v1

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -9,6 +9,17 @@ on:
       - "start.sh"
       - "doppler.yaml"
       - ".github/workflows/ci-e2e.yml"
+  # Only a push to main writes the sticky disks. Refer to the comment on the mount.
+  push:
+    branches: [main]
+    paths:
+      - "automation-testing/**"
+      - "web/nextjs/**"
+      - "server/nodejs/**"
+      - "docker-compose.yml"
+      - "start.sh"
+      - "doppler.yaml"
+      - ".github/workflows/ci-e2e.yml"
   workflow_dispatch:
 
 concurrency:
@@ -43,11 +54,15 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      # A pull_request run mounts read-only. Only a push to main commits the
+      # snapshot. This job injects Doppler secrets, so a disk that any fork PR
+      # could write would be a code-execution path beside those secrets.
       - name: Mount automation-testing node_modules (stickydisk)
         uses: useblacksmith/stickydisk@v1.4.0
         with:
           key: ${{ runner.os }}-counsel-studio-e2e-bun-${{ hashFiles('automation-testing/bun.lock') }}
           path: automation-testing/node_modules
+          commit: ${{ github.event_name == 'push' }}
 
       - name: Install automation-testing dependencies
         working-directory: ./automation-testing
@@ -84,6 +99,7 @@ jobs:
         with:
           key: ${{ runner.os }}-counsel-studio-e2e-playwright-${{ hashFiles('automation-testing/package.json', 'automation-testing/bun.lock') }}
           path: ~/.cache/ms-playwright
+          commit: ${{ github.event_name == 'push' }}
 
       # No --with-deps: blacksmith-4vcpu-ubuntu-2404 is based on GitHub's
       # ubuntu-24.04 runner image, which ships Playwright's system libs

--- a/.github/workflows/ci-nextjs-web.yml
+++ b/.github/workflows/ci-nextjs-web.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     paths:
       - "web/nextjs/**"
+  # Only a push to main writes the sticky disks. Refer to the comment on the mount.
+  push:
+    branches: [main]
+    paths:
+      - "web/nextjs/**"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,11 +26,15 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      # A pull_request run mounts read-only. Only a push to main commits the
+      # snapshot. This stops a fork PR from writing a disk that a later run,
+      # which does hold secrets, would then execute code from.
       - name: Mount node_modules cache
         uses: useblacksmith/stickydisk@v1.4.0
         with:
           key: ${{ runner.os }}-counsel-studio-web-bun-${{ hashFiles('web/nextjs/bun.lock') }}
           path: web/nextjs/node_modules
+          commit: ${{ github.event_name == 'push' }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -35,6 +44,7 @@ jobs:
         with:
           key: ${{ runner.os }}-counsel-studio-web-next-${{ hashFiles('web/nextjs/bun.lock') }}
           path: web/nextjs/.next/cache
+          commit: ${{ github.event_name == 'push' }}
 
       - name: Create env file
         run: |

--- a/.github/workflows/ci-nextjs-web.yml
+++ b/.github/workflows/ci-nextjs-web.yml
@@ -14,15 +14,27 @@ jobs:
       run:
         working-directory: ./web/nextjs
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: 1.3.11
 
+      - name: Mount node_modules cache
+        uses: useblacksmith/stickydisk@v1.4.0
+        with:
+          key: ${{ runner.os }}-counsel-studio-web-bun-${{ hashFiles('web/nextjs/bun.lock') }}
+          path: web/nextjs/node_modules
+
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Mount Next.js build cache
+        uses: useblacksmith/stickydisk@v1.4.0
+        with:
+          key: ${{ runner.os }}-counsel-studio-web-next-${{ hashFiles('web/nextjs/bun.lock') }}
+          path: web/nextjs/.next/cache
 
       - name: Create env file
         run: |

--- a/.github/workflows/ci-nextjs-web.yml
+++ b/.github/workflows/ci-nextjs-web.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: ./web/nextjs
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci-nodejs-server.yml
+++ b/.github/workflows/ci-nodejs-server.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     paths:
       - "server/nodejs/**"
+  # Only a push to main writes the sticky disk. Refer to the comment on the mount.
+  push:
+    branches: [main]
+    paths:
+      - "server/nodejs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,11 +27,15 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      # A pull_request run mounts read-only. Only a push to main commits the
+      # snapshot. This stops a fork PR from writing a disk that a later run,
+      # which does hold secrets, would then execute code from.
       - name: Mount node_modules cache
         uses: useblacksmith/stickydisk@v1.4.0
         with:
           key: ${{ runner.os }}-counsel-studio-server-bun-${{ hashFiles('server/nodejs/bun.lock') }}
           path: server/nodejs/node_modules
+          commit: ${{ github.event_name == 'push' }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci-nodejs-server.yml
+++ b/.github/workflows/ci-nodejs-server.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: ./server/nodejs
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci-nodejs-server.yml
+++ b/.github/workflows/ci-nodejs-server.yml
@@ -10,17 +10,23 @@ concurrency:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: ./server/nodejs
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: 1.3.11
+
+      - name: Mount node_modules cache
+        uses: useblacksmith/stickydisk@v1.4.0
+        with:
+          key: ${{ runner.os }}-counsel-studio-server-bun-${{ hashFiles('server/nodejs/bun.lock') }}
+          path: server/nodejs/node_modules
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Detect changed services
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4.0.2
         id: filter
         with:
           filters: |
@@ -57,10 +57,10 @@ jobs:
           token_format: access_token
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@v3.0.1
 
       - name: Login to Google Artifact Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.6.0
         with:
           registry: ${{ env.REGION }}-docker.pkg.dev
           username: _json_key
@@ -227,7 +227,7 @@ jobs:
           echo "nodejs_url=$NODEJS_URL" >> $GITHUB_OUTPUT
 
       - name: Update PR comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const marker = '<!-- pr-preview -->';
@@ -276,7 +276,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Google Auth
         uses: google-github-actions/auth@v3
@@ -284,7 +284,7 @@ jobs:
           credentials_json: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@v3.0.1
 
       - name: Delete preview services
         run: |

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Detect changed services
         uses: dorny/paths-filter@v3
@@ -57,7 +57,7 @@ jobs:
           token_format: access_token
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v4
@@ -227,7 +227,7 @@ jobs:
           echo "nodejs_url=$NODEJS_URL" >> $GITHUB_OUTPUT
 
       - name: Update PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- pr-preview -->';
@@ -284,7 +284,7 @@ jobs:
           credentials_json: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Delete preview services
         run: |

--- a/.github/workflows/purge-ci-caches.yml
+++ b/.github/workflows/purge-ci-caches.yml
@@ -1,0 +1,76 @@
+# Manual purge for the sticky disks that CI mounts.
+#
+# CI must never delete a sticky disk at the end of a run. A per-run delete throws
+# away the cache that the run just populated. Run this workflow by hand when a
+# cache is corrupt or stale.
+#
+# The delete-key values must match the stickydisk keys in ci-e2e.yml,
+# ci-nextjs-web.yml, and ci-nodejs-server.yml.
+
+name: Purge CI Caches
+
+on:
+  workflow_dispatch:
+    inputs:
+      e2e_node_modules:
+        description: "Delete the automation-testing node_modules sticky disk"
+        type: boolean
+        default: true
+      e2e_playwright:
+        description: "Delete the Playwright browsers sticky disk"
+        type: boolean
+        default: true
+      web_node_modules:
+        description: "Delete the web/nextjs node_modules sticky disk"
+        type: boolean
+        default: true
+      web_next_build:
+        description: "Delete the Next.js build cache sticky disk"
+        type: boolean
+        default: true
+      server_node_modules:
+        description: "Delete the server/nodejs node_modules sticky disk"
+        type: boolean
+        default: true
+
+jobs:
+  purge:
+    name: Purge Caches
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Delete automation-testing node_modules sticky disk
+        if: ${{ inputs.e2e_node_modules }}
+        uses: useblacksmith/stickydisk-delete@v1
+        continue-on-error: true
+        with:
+          delete-key: ${{ runner.os }}-counsel-studio-e2e-bun-${{ hashFiles('automation-testing/bun.lock') }}
+
+      - name: Delete Playwright browsers sticky disk
+        if: ${{ inputs.e2e_playwright }}
+        uses: useblacksmith/stickydisk-delete@v1
+        continue-on-error: true
+        with:
+          delete-key: ${{ runner.os }}-counsel-studio-e2e-playwright-${{ hashFiles('automation-testing/package.json', 'automation-testing/bun.lock') }}
+
+      - name: Delete web/nextjs node_modules sticky disk
+        if: ${{ inputs.web_node_modules }}
+        uses: useblacksmith/stickydisk-delete@v1
+        continue-on-error: true
+        with:
+          delete-key: ${{ runner.os }}-counsel-studio-web-bun-${{ hashFiles('web/nextjs/bun.lock') }}
+
+      - name: Delete Next.js build cache sticky disk
+        if: ${{ inputs.web_next_build }}
+        uses: useblacksmith/stickydisk-delete@v1
+        continue-on-error: true
+        with:
+          delete-key: ${{ runner.os }}-counsel-studio-web-next-${{ hashFiles('web/nextjs/bun.lock') }}
+
+      - name: Delete server/nodejs node_modules sticky disk
+        if: ${{ inputs.server_node_modules }}
+        uses: useblacksmith/stickydisk-delete@v1
+        continue-on-error: true
+        with:
+          delete-key: ${{ runner.os }}-counsel-studio-server-bun-${{ hashFiles('server/nodejs/bun.lock') }}

--- a/automation-testing/package.json
+++ b/automation-testing/package.json
@@ -10,7 +10,7 @@
     "test:e2e:api:ci": "CI=true API_BASE_URL=http://127.0.0.1:4003 WEB_BASE_URL=http://127.0.0.1:3001 bunx playwright test --project=api",
     "test:e2e:ui:ci": "CI=true API_BASE_URL=http://127.0.0.1:4003 WEB_BASE_URL=http://127.0.0.1:3001 bunx playwright test --project=ui",
     "playwright:install": "bunx playwright install chromium",
-    "playwright:install:ci": "bunx playwright install chromium --with-deps",
+    "playwright:install:ci": "bunx playwright install chromium",
     "lint": "oxlint api/ ui/ playwright.config.ts",
     "format": "oxfmt 'api/**/*.ts' 'ui/**/*.ts' playwright.config.ts",
     "format:check": "oxfmt --check 'api/**/*.ts' 'ui/**/*.ts' playwright.config.ts",


### PR DESCRIPTION
- pin every action to an exact patch version, matching counsel-main
- upgrade checkout v7, upload-artifact v7, github-script v9, paths-filter v4, doppler v2, setup-gcloud v3
- stop deleting sticky disks per run; add a manual Purge CI Caches workflow instead
- cache node_modules and the Next.js build for the web and server CI jobs
- drop Playwright `--with-deps` and right-size runners: Android 8vcpu, lint/cleanup jobs 2vcpu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI secret injection (Doppler v2) and cache write policy around fork PRs; misconfiguration could affect e2e or cache integrity, but the read-only PR mount is a security improvement.
> 
> **Overview**
> Aligns GitHub Actions with **counsel-main** by **pinning actions to exact patch versions** (e.g. `checkout@v7.0.1`, `setup-bun@v2.2.0`, `stickydisk@v1.4.0`) and bumping several majors/minors (Doppler fetch **v2**, `upload-artifact` **v7**, `github-script` **v9**, `paths-filter` **v4**, `setup-gcloud` **v3**).
> 
> **Sticky-disk caching** is expanded: web and server CI mount `node_modules` (and Next.js `.next/cache` for web); e2e keeps bun + Playwright browser caches. Disks **commit only on `push` to `main`** (`commit: ${{ github.event_name == 'push' }}`) so fork PRs mount read-only and cannot poison caches used beside secrets. The e2e **post-run `stickydisk-delete` job is removed**; a new **manual `Purge CI Caches`** workflow deletes disks when needed.
> 
> **Runner and e2e tweaks**: Android moves to **blacksmith-8vcpu**; lint-only / cleanup jobs use **2vcpu**; e2e lint job **2vcpu** (was 4). E2E gains **`push` on `main`** (same paths), **20-minute timeout**, and Playwright CI install **drops `--with-deps`** (ubuntu-24.04 image already has libs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9006161e9113e5f0d7c88a6a9798c723063f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->