### PR TITLE
internal(ci): always report required checks and give each a distinct name

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,10 +1,10 @@
 name: Android
 
 on:
+  # build is a required check. A path filter here would skip the whole
+  # workflow and leave it pending forever, blocking the PR. The filter
+  # lives in the changes job below instead, so the check always reports.
   pull_request:
-    paths:
-      - "mobile/android/**"
-      - ".github/workflows/android.yml"
   push:
     branches: [main]
     paths:
@@ -16,7 +16,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: dorny/paths-filter@v4.0.2
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'mobile/android/**'
+              - '.github/workflows/android.yml'
+
   build:
+    needs: changes
     runs-on: blacksmith-8vcpu-ubuntu-2404
     defaults:
       run:
@@ -25,30 +41,36 @@ jobs:
       - uses: actions/checkout@v7.0.1
 
       - name: Set up JDK 17
+        if: needs.changes.outputs.relevant == 'true'
         uses: actions/setup-java@v5.7.0
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Gradle
+        if: needs.changes.outputs.relevant == 'true'
         uses: gradle/actions/setup-gradle@v6.3.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Detekt (static analysis + ktlint formatting)
+        if: needs.changes.outputs.relevant == 'true'
         run: ./gradlew :app:detekt --no-daemon --stacktrace
 
       - name: Lint
+        if: needs.changes.outputs.relevant == 'true'
         run: ./gradlew :app:lint --no-daemon --stacktrace
 
       - name: Unit tests
+        if: needs.changes.outputs.relevant == 'true'
         run: ./gradlew :app:test --no-daemon --stacktrace
 
       - name: Assemble debug APK
+        if: needs.changes.outputs.relevant == 'true'
         run: ./gradlew :app:assembleDebug --no-daemon --stacktrace
 
       - name: Upload detekt report
-        if: failure()
+        if: failure() && needs.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@v7.0.1
         with:
           name: detekt-report
@@ -57,7 +79,7 @@ jobs:
           retention-days: 14
 
       - name: Upload debug APK
-        if: success()
+        if: success() && needs.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@v7.0.1
         with:
           name: app-debug

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,7 +1,7 @@
 name: Android
 
 on:
-  # build is a required check. A path filter here would skip the whole
+  # build-android is a required check. A path filter here would skip the whole
   # workflow and leave it pending forever, blocking the PR. The filter
   # lives in the changes job below instead, so the check always reports.
   pull_request:
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   changes:
+    name: changes-android
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -32,6 +33,7 @@ jobs:
               - '.github/workflows/android.yml'
 
   build:
+    name: build-android
     needs: changes
     runs-on: blacksmith-8vcpu-ubuntu-2404
     defaults:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,8 +1,8 @@
 name: E2E
 on:
-  # build and e2e are required checks. A path filter here would skip the whole
-  # workflow and leave both pending forever, blocking the PR. The filter lives
-  # in the changes job below instead, so the checks always report.
+  # build-automation and e2e are required checks. A path filter here would skip
+  # the whole workflow and leave both pending forever, blocking the PR. The
+  # filter lives in the changes job below instead, so the checks always report.
   pull_request:
   # Only a push to main writes the sticky disks. Refer to the comment on the mount.
   push:
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   changes:
+    name: changes-automation
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -43,6 +44,7 @@ jobs:
               - '.github/workflows/ci-e2e.yml'
 
   build:
+    name: build-automation
     needs: changes
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:

--- a/.github/workflows/ci-nextjs-web.yml
+++ b/.github/workflows/ci-nextjs-web.yml
@@ -1,9 +1,10 @@
 name: Next.js Web App CI
 on:
   workflow_dispatch:
+  # build is a required check. A path filter here would skip the whole
+  # workflow and leave it pending forever, blocking the PR. The filter
+  # lives in the changes job below instead, so the check always reports.
   pull_request:
-    paths:
-      - "web/nextjs/**"
   # Only a push to main writes the sticky disks. Refer to the comment on the mount.
   push:
     branches: [main]
@@ -13,7 +14,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: dorny/paths-filter@v4.0.2
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'web/nextjs/**'
+
   build:
+    needs: changes
     runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
       run:
@@ -22,6 +38,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
+        if: needs.changes.outputs.relevant == 'true'
         uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: 1.3.11
@@ -30,6 +47,7 @@ jobs:
       # snapshot. This stops a fork PR from writing a disk that a later run,
       # which does hold secrets, would then execute code from.
       - name: Mount node_modules cache
+        if: needs.changes.outputs.relevant == 'true'
         uses: useblacksmith/stickydisk@v1.4.0
         with:
           key: ${{ runner.os }}-counsel-studio-web-bun-${{ hashFiles('web/nextjs/bun.lock') }}
@@ -37,9 +55,11 @@ jobs:
           commit: ${{ github.event_name == 'push' }}
 
       - name: Install dependencies
+        if: needs.changes.outputs.relevant == 'true'
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Mount Next.js build cache
+        if: needs.changes.outputs.relevant == 'true'
         uses: useblacksmith/stickydisk@v1.4.0
         with:
           key: ${{ runner.os }}-counsel-studio-web-next-${{ hashFiles('web/nextjs/bun.lock') }}
@@ -47,17 +67,21 @@ jobs:
           commit: ${{ github.event_name == 'push' }}
 
       - name: Create env file
+        if: needs.changes.outputs.relevant == 'true'
         run: |
           touch .env
           echo IRON_SESSION_PASSWORD=test-password >> .env
           cat .env
 
       - name: Lint
+        if: needs.changes.outputs.relevant == 'true'
         run: bun run lint
 
       # Handles type checking too
       - name: Build
+        if: needs.changes.outputs.relevant == 'true'
         run: bun run build
 
       - name: Test
+        if: needs.changes.outputs.relevant == 'true'
         run: bun run test

--- a/.github/workflows/ci-nextjs-web.yml
+++ b/.github/workflows/ci-nextjs-web.yml
@@ -1,7 +1,7 @@
 name: Next.js Web App CI
 on:
   workflow_dispatch:
-  # build is a required check. A path filter here would skip the whole
+  # build-web is a required check. A path filter here would skip the whole
   # workflow and leave it pending forever, blocking the PR. The filter
   # lives in the changes job below instead, so the check always reports.
   pull_request:
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   changes:
+    name: changes-web
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -29,6 +30,7 @@ jobs:
               - 'web/nextjs/**'
 
   build:
+    name: build-web
     needs: changes
     runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:

--- a/.github/workflows/ci-nodejs-server.yml
+++ b/.github/workflows/ci-nodejs-server.yml
@@ -1,6 +1,6 @@
 name: Node.js Server CI
 on:
-  # build is a required check. A path filter here would skip the whole
+  # build-server is a required check. A path filter here would skip the whole
   # workflow and leave it pending forever, blocking the PR. The filter
   # lives in the changes job below instead, so the check always reports.
   pull_request:
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   changes:
+    name: changes-server
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -30,6 +31,7 @@ jobs:
               - 'server/nodejs/**'
 
   build:
+    name: build-server
     needs: changes
     runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:

--- a/.github/workflows/ci-nodejs-server.yml
+++ b/.github/workflows/ci-nodejs-server.yml
@@ -1,8 +1,9 @@
 name: Node.js Server CI
 on:
+  # build is a required check. A path filter here would skip the whole
+  # workflow and leave it pending forever, blocking the PR. The filter
+  # lives in the changes job below instead, so the check always reports.
   pull_request:
-    paths:
-      - "server/nodejs/**"
   # Only a push to main writes the sticky disk. Refer to the comment on the mount.
   push:
     branches: [main]
@@ -14,7 +15,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: dorny/paths-filter@v4.0.2
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'server/nodejs/**'
+
   build:
+    needs: changes
     runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
@@ -23,6 +39,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
+        if: needs.changes.outputs.relevant == 'true'
         uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: 1.3.11
@@ -31,6 +48,7 @@ jobs:
       # snapshot. This stops a fork PR from writing a disk that a later run,
       # which does hold secrets, would then execute code from.
       - name: Mount node_modules cache
+        if: needs.changes.outputs.relevant == 'true'
         uses: useblacksmith/stickydisk@v1.4.0
         with:
           key: ${{ runner.os }}-counsel-studio-server-bun-${{ hashFiles('server/nodejs/bun.lock') }}
@@ -38,9 +56,11 @@ jobs:
           commit: ${{ github.event_name == 'push' }}
 
       - name: Install dependencies
+        if: needs.changes.outputs.relevant == 'true'
         run: bun install --frozen-lockfile
 
       - name: Create env file
+        if: needs.changes.outputs.relevant == 'true'
         run: bun run ci:write-env
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
@@ -49,16 +69,21 @@ jobs:
           COUNSEL_PRIVATE_KEY_PEM: ${{ secrets.COUNSEL_PRIVATE_KEY_PEM }}
 
       - name: Lint
+        if: needs.changes.outputs.relevant == 'true'
         run: bun run lint
 
       - name: Test
+        if: needs.changes.outputs.relevant == 'true'
         run: bun run test
 
       - name: Type Check
+        if: needs.changes.outputs.relevant == 'true'
         run: bun run build
 
       - name: Compile
+        if: needs.changes.outputs.relevant == 'true'
         run: bun run compile
 
       - name: Healthcheck
+        if: needs.changes.outputs.relevant == 'true'
         run: bun run healthcheck


### PR DESCRIPTION
- Remove the `pull_request` path filters from `ci-nextjs-web.yml`, `ci-nodejs-server.yml`, and `android.yml`.
- Move each filter into a `changes` job and gate the steps, so checks always report and no-op when nothing relevant changed.
- Name each job distinctly: `build-web`, `build-server`, `build-android`, `build-automation`, and the matching `changes-*`.
- Four workflows previously all reported a check called `build`, so the required context was ambiguous.
- Push triggers keep their path filters, so sticky disks still only commit on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no application code or secrets handling logic is modified beyond when steps run.
> 
> **Overview**
> **Required PR checks** (`build-android`, `build-web`, `build-server`) were stuck pending when `pull_request` path filters skipped the whole workflow. This change removes those top-level path filters on pull requests and applies the same **changes job + gated steps** pattern already used in `ci-e2e.yml`.
> 
> Each affected workflow now runs a lightweight `changes-*` job with `dorny/paths-filter`; the named `build-*` job always runs on PRs but **no-ops** (steps skipped) when nothing relevant changed. **Push to `main` path filters are unchanged**, so sticky-disk commits still only happen for real area changes.
> 
> `ci-e2e.yml` is aligned with explicit job names (`changes-automation`, `build-automation`) and an updated comment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31b8e6ccdb866ca66b4fbc1c3cf84a07248a21da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->